### PR TITLE
Add interactive session management commands

### DIFF
--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -10,6 +10,8 @@ import (
 	"late/internal/orchestrator"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"late/internal/assets"
 	"late/internal/client"
@@ -37,7 +39,12 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of late:\n")
-		fmt.Fprintf(os.Stderr, "  late [flags]\n\n")
+		fmt.Fprintf(os.Stderr, "  late [flags]\n")
+		fmt.Fprintf(os.Stderr, "  late session <command> [args]\n\n")
+		fmt.Fprintf(os.Stderr, "Commands:\n")
+		fmt.Fprintf(os.Stderr, "  session list     List all saved sessions\n")
+		fmt.Fprintf(os.Stderr, "  session load <id>  Load a session by ID\n")
+		fmt.Fprintf(os.Stderr, "  session delete <id>  Delete a session by ID\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -45,6 +52,15 @@ func main() {
 	if *helpReq {
 		flag.Usage()
 		return
+	}
+
+	var loadedHistoryPath string
+	if flag.NArg() > 0 && flag.Arg(0) == "session" {
+		path, shouldExit := handleSessionCommand(flag.Args()[1:])
+		if shouldExit {
+			return
+		}
+		loadedHistoryPath = path
 	}
 
 	// Determine system prompt
@@ -89,25 +105,36 @@ func main() {
 
 	fmt.Println("Starting late TUI...")
 
-	// Define history path
-	homeDir, err := os.UserHomeDir()
+	// Define history path with timestamp-based session ID
+	sessionsDir, err := session.SessionDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get user home dir: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to get session directory: %v\n", err)
 		os.Exit(1)
 	}
-	historyPath := filepath.Join(homeDir, ".local", "share", "late", "history.json")
+	sessionID := fmt.Sprintf("session-%s", time.Now().Format("20060102-150405"))
+	historyPath := filepath.Join(sessionsDir, sessionID+".json")
+
+	if loadedHistoryPath != "" {
+		historyPath = loadedHistoryPath
+	}
 
 	// Delete prior session history if --new-session is set
 	if *enableNewSessionReq {
-		if err := os.Remove(historyPath); err != nil {
-			if os.IsNotExist(err) {
-				fmt.Fprintf(os.Stderr, "Note: No prior session history to delete at %s\n", historyPath)
-			} else {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to delete prior session history at %s: %v\n", historyPath, err)
+		// Delete all session files
+		entries, _ := os.ReadDir(sessionsDir)
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+				os.Remove(filepath.Join(sessionsDir, entry.Name()))
 			}
-		} else {
-			fmt.Fprintf(os.Stderr, "Deleted prior session history at %s\n", historyPath)
 		}
+		// Also delete metadata files
+		entries, _ = os.ReadDir(sessionsDir)
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".meta.json") {
+				os.Remove(filepath.Join(sessionsDir, entry.Name()))
+			}
+		}
+		fmt.Fprintf(os.Stderr, "Deleted all session history\n")
 	}
 
 	// Load existing history
@@ -230,6 +257,142 @@ func main() {
 		fmt.Printf("Alas, there's been an error: %v", err)
 		os.Exit(1)
 	}
+}
+
+// handleSessionCommand processes session subcommands
+func handleSessionCommand(args []string) (string, bool) {
+	if len(args) == 0 {
+		fmt.Println("Usage: late session <list|load|delete> [args...]")
+		fmt.Println("")
+		fmt.Println("Commands:")
+		fmt.Println("  list           List all saved sessions")
+		fmt.Println("  load <id>      Load a session by ID (can use prefix)")
+		fmt.Println("  delete <id>    Delete a session by ID")
+		return "", true
+	}
+
+	switch args[0] {
+	case "list":
+		handleSessionList()
+		return "", true
+	case "load":
+		if len(args) < 2 {
+			fmt.Println("Error: session ID required")
+			fmt.Println("Usage: late session load <id>")
+			os.Exit(1)
+		}
+		return handleSessionLoad(args[1]), false
+	case "delete":
+		if len(args) < 2 {
+			fmt.Println("Error: session ID required")
+			fmt.Println("Usage: late session delete <id>")
+			os.Exit(1)
+		}
+		handleSessionDelete(args[1])
+		return "", true
+	default:
+		fmt.Printf("Unknown session command: %s\n", args[0])
+		handleSessionCommand([]string{})
+		return "", true
+	}
+}
+
+// handleSessionList displays all saved sessions
+func handleSessionList() {
+	metas, err := session.ListSessions()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing sessions: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(metas) == 0 {
+		fmt.Println("No sessions found.")
+		fmt.Println("")
+		fmt.Println("Use 'late session load <id>' to load a saved session or start a new session with 'late'.")
+		return
+	}
+
+	fmt.Println("Available sessions:")
+	fmt.Println("")
+	for _, meta := range metas {
+		// Use Blue for the ID to make it stand out
+		fmt.Printf("\033[36mID: %s\033[0m\n", strings.TrimSuffix(meta.ID, ".json"))
+		fmt.Printf("    Title:   %s\n", meta.Title)
+		fmt.Printf("    Created: %s\n", meta.CreatedAt.Format("2006-01-02 15:04:05"))
+		fmt.Printf("    Updated: %s\n", meta.LastUpdated.Format("2006-01-02 15:04:05"))
+		fmt.Printf("    Msg #:   %d\n", meta.MessageCount)
+		if meta.LastUserPrompt != "" {
+			last := meta.LastUserPrompt
+			if len(last) > 50 {
+				last = last[:47] + "..."
+			}
+			fmt.Printf("    Last:    %s\n", last)
+		}
+		fmt.Println("")
+	}
+	fmt.Println("To resume, use: \033[1mlate session load <id>\033[0m")
+}
+
+// handleSessionLoad returns the history path for the given session ID
+func handleSessionLoad(id string) string {
+	meta, err := session.LoadSessionMeta(id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading session: %v\n", err)
+		os.Exit(1)
+	}
+	if meta == nil {
+		fmt.Fprintf(os.Stderr, "Session not found: %s\n", id)
+		fmt.Println("")
+		fmt.Println("Use 'late session list' to see available sessions.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Resuming session: %s (%s)\n", meta.ID, meta.Title)
+	time.Sleep(500 * time.Millisecond) // Give user a moment to see what's happening
+	return meta.HistoryPath
+}
+
+// handleSessionDelete removes a session
+func handleSessionDelete(id string) {
+	meta, err := session.LoadSessionMeta(id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading session: %v\n", err)
+		os.Exit(1)
+	}
+	if meta == nil {
+		fmt.Fprintf(os.Stderr, "Session not found: %s\n", id)
+		fmt.Println("")
+		fmt.Println("Use 'late session list' to see available sessions.")
+		os.Exit(1)
+	}
+
+	// Delete metadata
+	metaPath := filepath.Join(filepath.Dir(meta.HistoryPath), "..", "sessions", meta.ID+".meta.json")
+	if err := os.Remove(metaPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error deleting metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Delete history file
+	if err := os.Remove(meta.HistoryPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error deleting history: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Deleted session: %s\n", meta.Title)
+}
+
+// printUsage displays the complete usage information
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage of late:\n")
+	fmt.Fprintf(os.Stderr, "  late [flags]\n")
+	fmt.Fprintf(os.Stderr, "  late session <command> [args]\n\n")
+	fmt.Fprintf(os.Stderr, "Commands:\n")
+	fmt.Fprintf(os.Stderr, "  session list     List all saved sessions\n")
+	fmt.Fprintf(os.Stderr, "  session load <id>  Load a session by ID\n")
+	fmt.Fprintf(os.Stderr, "  session delete <id>  Delete a session by ID\n\n")
+	fmt.Fprintf(os.Stderr, "Flags:\n")
+	flag.PrintDefaults()
 }
 
 // ForwardOrchestratorEvents is a helper that recursively forwards all events from an orchestrator

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -121,17 +121,27 @@ func main() {
 	// Delete prior session history if --new-session is set
 	if *enableNewSessionReq {
 		// Delete all session files
-		entries, _ := os.ReadDir(sessionsDir)
+		entries, err := os.ReadDir(sessionsDir)
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to list sessions dir: %v\n", err)
+		}
 		for _, entry := range entries {
 			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
-				os.Remove(filepath.Join(sessionsDir, entry.Name()))
+				if err := os.Remove(filepath.Join(sessionsDir, entry.Name())); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", entry.Name(), err)
+				}
 			}
 		}
 		// Also delete metadata files
-		entries, _ = os.ReadDir(sessionsDir)
+		entries, err = os.ReadDir(sessionsDir)
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to list sessions dir: %v\n", err)
+		}
 		for _, entry := range entries {
 			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".meta.json") {
-				os.Remove(filepath.Join(sessionsDir, entry.Name()))
+				if err := os.Remove(filepath.Join(sessionsDir, entry.Name())); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", entry.Name(), err)
+				}
 			}
 		}
 		fmt.Fprintf(os.Stderr, "Deleted all session history\n")
@@ -315,22 +325,10 @@ func handleSessionList() {
 	fmt.Println("Available sessions:")
 	fmt.Println("")
 	for _, meta := range metas {
-		// Use Blue for the ID to make it stand out
-		fmt.Printf("\033[36mID: %s\033[0m\n", strings.TrimSuffix(meta.ID, ".json"))
-		fmt.Printf("    Title:   %s\n", meta.Title)
-		fmt.Printf("    Created: %s\n", meta.CreatedAt.Format("2006-01-02 15:04:05"))
-		fmt.Printf("    Updated: %s\n", meta.LastUpdated.Format("2006-01-02 15:04:05"))
-		fmt.Printf("    Msg #:   %d\n", meta.MessageCount)
-		if meta.LastUserPrompt != "" {
-			last := meta.LastUserPrompt
-			if len(last) > 50 {
-				last = last[:47] + "..."
-			}
-			fmt.Printf("    Last:    %s\n", last)
-		}
+		fmt.Println(session.FormatSessionDisplay(meta))
 		fmt.Println("")
 	}
-	fmt.Println("To resume, use: \033[1mlate session load <id>\033[0m")
+	fmt.Println(session.FormatResumePrompt())
 }
 
 // handleSessionLoad returns the history path for the given session ID
@@ -367,7 +365,12 @@ func handleSessionDelete(id string) {
 	}
 
 	// Delete metadata
-	metaPath := filepath.Join(filepath.Dir(meta.HistoryPath), "..", "sessions", meta.ID+".meta.json")
+	sessionsDir, err := session.SessionDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting session directory: %v\n", err)
+		os.Exit(1)
+	}
+	metaPath := filepath.Join(sessionsDir, meta.ID+".meta.json")
 	if err := os.Remove(metaPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error deleting metadata: %v\n", err)
 		os.Exit(1)

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -10,7 +10,6 @@ import (
 	"late/internal/orchestrator"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"late/internal/assets"
@@ -35,7 +34,6 @@ func main() {
 	injectCWDReq := flag.Bool("inject-cwd", true, "Replace ${{CWD}} in system prompt with current working directory")
 	enableSubagentsReq := flag.Bool("enable-subagents", true, "Enable subagent usage")
 	enableAskToolReq := flag.Bool("enable-ask-tool", false, "Enable ask tool for user input")
-	enableNewSessionReq := flag.Bool("new-session", false, "Delete prior session history and start with a clean chat window")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of late:\n")
@@ -118,34 +116,7 @@ func main() {
 		historyPath = loadedHistoryPath
 	}
 
-	// Delete prior session history if --new-session is set
-	if *enableNewSessionReq {
-		// Delete all session files
-		entries, err := os.ReadDir(sessionsDir)
-		if err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to list sessions dir: %v\n", err)
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
-				if err := os.Remove(filepath.Join(sessionsDir, entry.Name())); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", entry.Name(), err)
-				}
-			}
-		}
-		// Also delete metadata files
-		entries, err = os.ReadDir(sessionsDir)
-		if err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to list sessions dir: %v\n", err)
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".meta.json") {
-				if err := os.Remove(filepath.Join(sessionsDir, entry.Name())); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", entry.Name(), err)
-				}
-			}
-		}
-		fmt.Fprintf(os.Stderr, "Deleted all session history\n")
-	}
+	
 
 	// Load existing history
 	history, err := session.LoadHistory(historyPath)
@@ -385,18 +356,7 @@ func handleSessionDelete(id string) {
 	fmt.Printf("Deleted session: %s\n", meta.Title)
 }
 
-// printUsage displays the complete usage information
-func printUsage() {
-	fmt.Fprintf(os.Stderr, "Usage of late:\n")
-	fmt.Fprintf(os.Stderr, "  late [flags]\n")
-	fmt.Fprintf(os.Stderr, "  late session <command> [args]\n\n")
-	fmt.Fprintf(os.Stderr, "Commands:\n")
-	fmt.Fprintf(os.Stderr, "  session list     List all saved sessions\n")
-	fmt.Fprintf(os.Stderr, "  session load <id>  Load a session by ID\n")
-	fmt.Fprintf(os.Stderr, "  session delete <id>  Delete a session by ID\n\n")
-	fmt.Fprintf(os.Stderr, "Flags:\n")
-	flag.PrintDefaults()
-}
+
 
 // ForwardOrchestratorEvents is a helper that recursively forwards all events from an orchestrator
 // to the Bubble Tea program.

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -104,8 +104,10 @@ func LoadSessionMeta(id string) (*SessionMeta, error) {
 		return nil, fmt.Errorf("session ID %q is ambiguous, matches: %s", id, strings.Join(matches, ", "))
 	}
 
-	// Exactly one match
-	return LoadSessionMeta(matches[0])
+	// Exactly one match — use the matched name to build exact path
+	matchedName := matches[0]
+	exactPath = filepath.Join(sessionsDir, matchedName+".meta.json")
+	return loadMetaFile(exactPath)
 }
 
 // loadMetaFile handles the actual reading and unmarshaling

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -1,0 +1,158 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SessionMeta represents metadata about a saved session
+type SessionMeta struct {
+	ID             string    `json:"id"`
+	Title          string    `json:"title"` // Short title derived from first user message
+	CreatedAt      time.Time `json:"created_at"`
+	LastUpdated    time.Time `json:"last_updated"`
+	HistoryPath    string    `json:"history_path"`     // Full path to history file
+	LastUserPrompt string    `json:"last_user_prompt"` // Last 100 chars of last user message
+	MessageCount   int       `json:"message_count"`
+}
+
+// SessionDir returns the directory where session metadata and histories are stored
+var SessionDir = func() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".local", "share", "late", "sessions"), nil
+}
+
+// SaveSessionMeta saves session metadata to the sessions directory
+func SaveSessionMeta(meta SessionMeta) error {
+	sessionsDir, err := SessionDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create sessions directory: %w", err)
+	}
+
+	metaPath := filepath.Join(sessionsDir, meta.ID+".meta.json")
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session meta: %w", err)
+	}
+
+	// Atomic write
+	tmpFile, err := os.CreateTemp(sessionsDir, "meta-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write to temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile.Name(), metaPath); err != nil {
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadSessionMeta loads session metadata by ID or prefix
+func LoadSessionMeta(id string) (*SessionMeta, error) {
+	sessionsDir, err := SessionDir()
+	if err != nil {
+		return nil, err
+	}
+
+	// Try exact match first
+	exactPath := filepath.Join(sessionsDir, id+".meta.json")
+	if _, err := os.Stat(exactPath); err == nil {
+		return loadMetaFile(exactPath)
+	}
+
+	// Try prefix match
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".meta.json") {
+			name := strings.TrimSuffix(entry.Name(), ".meta.json")
+			if strings.HasPrefix(name, id) {
+				matches = append(matches, name)
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, nil // Not found
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("session ID %q is ambiguous, matches: %s", id, strings.Join(matches, ", "))
+	}
+
+	// Exactly one match
+	return LoadSessionMeta(matches[0])
+}
+
+// loadMetaFile handles the actual reading and unmarshaling
+func loadMetaFile(path string) (*SessionMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session meta: %w", err)
+	}
+
+	var meta SessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session meta: %w", err)
+	}
+
+	return &meta, nil
+}
+
+// ListSessions returns all session metadata, sorted by last_updated descending
+func ListSessions() ([]SessionMeta, error) {
+	sessionsDir, err := SessionDir()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []SessionMeta{}, nil
+		}
+		return nil, fmt.Errorf("failed to read sessions directory: %w", err)
+	}
+
+	var metas []SessionMeta
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".meta.json") {
+			id := strings.TrimSuffix(entry.Name(), ".meta.json")
+			meta, err := LoadSessionMeta(id)
+			if err == nil && meta != nil {
+				metas = append(metas, *meta)
+			}
+		}
+	}
+
+	// Sort by last_updated descending
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].LastUpdated.After(metas[j].LastUpdated)
+	})
+
+	return metas, nil
+}

--- a/internal/session/models_test.go
+++ b/internal/session/models_test.go
@@ -1,0 +1,65 @@
+package session
+
+import (
+	"late/internal/client"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSessionMeta(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "late-session-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	defer func() { SessionDir = oldSessionDir }()
+
+	historyPath := filepath.Join(tmpDir, "session-test.json")
+	history := []client.ChatMessage{{Role: "user", Content: "Hello"}}
+
+	s := New(nil, historyPath, history, "", false)
+	meta := s.GenerateSessionMeta()
+
+	if meta.ID != "session-test" {
+		t.Errorf("Expected ID 'session-test', got %q", meta.ID)
+	}
+
+	if err := SaveSessionMeta(meta); err != nil {
+		t.Errorf("Failed to save meta: %v", err)
+	}
+
+	// Test exact load
+	loaded, err := LoadSessionMeta("session-test")
+	if err != nil || loaded == nil {
+		t.Fatalf("Failed to load meta exactly: %v", err)
+	}
+	if loaded.ID != "session-test" {
+		t.Errorf("Expected loaded ID 'session-test', got %q", loaded.ID)
+	}
+
+	// Test prefix load
+	loadedPrefix, err := LoadSessionMeta("session-")
+	if err != nil || loadedPrefix == nil {
+		t.Fatalf("Failed to load meta by prefix: %v", err)
+	}
+	if loadedPrefix.ID != "session-test" {
+		t.Errorf("Expected loaded prefix ID 'session-test', got %q", loadedPrefix.ID)
+	}
+
+	// Test ambiguous prefix
+	meta2 := meta
+	meta2.ID = "session-other"
+	SaveSessionMeta(meta2)
+
+	_, err = LoadSessionMeta("session-")
+	if err == nil {
+		t.Error("Expected error for ambiguous prefix, got nil")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -34,7 +34,6 @@ func New(c *client.Client, historyPath string, history []client.ChatMessage, sys
 }
 
 // ExecuteTool executes a tool call and returns the response as a string.
-// ExecuteTool executes a tool call and returns the response as a string.
 func (s *Session) ExecuteTool(ctx context.Context, tc client.ToolCall) (string, error) {
 	// First check registry
 	t := s.Registry.Get(tc.Function.Name)
@@ -219,7 +218,7 @@ func (s *Session) GenerateSessionMeta() SessionMeta {
 			if msg.Role == "user" && title == "Untitled Session" {
 				truncated := msg.Content
 				if len(truncated) > 100 {
-					truncated = truncated[:97] + "..."
+					truncated = truncateUTF8(truncated, 100)
 				}
 				title = truncated
 				break
@@ -230,7 +229,7 @@ func (s *Session) GenerateSessionMeta() SessionMeta {
 			if s.History[i].Role == "user" {
 				lastPrompt = s.History[i].Content
 				if len(lastPrompt) > 50 {
-					lastPrompt = lastPrompt[:47] + "..."
+					lastPrompt = truncateUTF8(lastPrompt, 50)
 				}
 				break
 			}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -7,7 +7,9 @@ import (
 	"late/internal/client"
 	"late/internal/common"
 	"late/internal/tool"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Session manages the chat state and interacts with the LLM client.
@@ -49,7 +51,7 @@ func (s *Session) AddToolResultMessage(toolCallID, content string) error {
 		ToolCallID: toolCallID,
 		Content:    content,
 	})
-	return SaveHistory(s.HistoryPath, s.History)
+	return s.saveAndNotify()
 }
 
 // AddAssistantMessageWithTools adds an assistant message with tool calls.
@@ -60,7 +62,7 @@ func (s *Session) AddAssistantMessageWithTools(content string, reasoning string,
 		ReasoningContent: reasoning,
 		ToolCalls:        toolCalls,
 	})
-	return SaveHistory(s.HistoryPath, s.History)
+	return s.saveAndNotify()
 }
 
 func (s *Session) GetToolDefinitions() []client.ToolDefinition {
@@ -82,7 +84,7 @@ func (s *Session) GetToolDefinitions() []client.ToolDefinition {
 // AddUserMessage adds a user message to history and persists it.
 func (s *Session) AddUserMessage(content string) error {
 	s.History = append(s.History, client.ChatMessage{Role: "user", Content: content})
-	return SaveHistory(s.HistoryPath, s.History)
+	return s.saveAndNotify()
 }
 
 // AddAssistantMessage adds an assistant message to history and persists it.
@@ -92,7 +94,7 @@ func (s *Session) AddAssistantMessage(content, reasoning string) error {
 		Content:          content,
 		ReasoningContent: reasoning,
 	})
-	return SaveHistory(s.HistoryPath, s.History)
+	return s.saveAndNotify()
 }
 
 // AppendToLastMessage appends content to the last message (continuation).
@@ -109,7 +111,7 @@ func (s *Session) AppendToLastMessage(content, reasoning string) error {
 			s.History[lastIdx].ReasoningContent = reasoning
 		}
 	}
-	return SaveHistory(s.HistoryPath, s.History)
+	return s.saveAndNotify()
 }
 
 // StartStream initiates a streaming response.
@@ -189,13 +191,13 @@ func (s *Session) StartStream(ctx context.Context, extraBody map[string]any) (<-
 func (s *Session) Impersonate(ctx context.Context) (string, error) {
 	var sb strings.Builder
 	for _, msg := range s.History {
-		sb.WriteString(fmt.Sprintf("<|im_start|>%s\n%s<|im_end|>\n", msg.Role, msg.Content))
+		sb.WriteString(fmt.Sprintf("%s\n%s\n", msg.Role, msg.Content))
 	}
-	prompt := sb.String() + "<|im_start|>user\n"
+	prompt := sb.String() + "user\n"
 
 	req := client.CompletionRequest{
 		Prompt:    prompt,
-		Stop:      []string{"<|im_end|>", "<|im_start|>"},
+		Stop:      []string{"\n", ""},
 		N_Predict: 50,
 	}
 
@@ -204,4 +206,63 @@ func (s *Session) Impersonate(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return resp.Content, nil
+}
+
+// GenerateSessionMeta creates metadata from session state
+func (s *Session) GenerateSessionMeta() SessionMeta {
+	title := "Untitled Session"
+	lastPrompt := ""
+
+	if len(s.History) > 0 {
+		// Find first user message for title
+		for _, msg := range s.History {
+			if msg.Role == "user" && title == "Untitled Session" {
+				truncated := msg.Content
+				if len(truncated) > 100 {
+					truncated = truncated[:97] + "..."
+				}
+				title = truncated
+				break
+			}
+		}
+		// Last user message for last prompt
+		for i := len(s.History) - 1; i >= 0; i-- {
+			if s.History[i].Role == "user" {
+				lastPrompt = s.History[i].Content
+				if len(lastPrompt) > 50 {
+					lastPrompt = lastPrompt[:47] + "..."
+				}
+				break
+			}
+		}
+	}
+
+	id := filepath.Base(s.HistoryPath)
+	id = strings.TrimSuffix(id, ".json")
+
+	return SessionMeta{
+		ID:             id,
+		Title:          title,
+		CreatedAt:      time.Now(),
+		LastUpdated:    time.Now(),
+		HistoryPath:    s.HistoryPath,
+		LastUserPrompt: lastPrompt,
+		MessageCount:   len(s.History),
+	}
+}
+
+// UpdateSessionMetadata updates the session metadata file
+func (s *Session) UpdateSessionMetadata() error {
+	meta := s.GenerateSessionMeta()
+	return SaveSessionMeta(meta)
+}
+
+func (s *Session) saveAndNotify() error {
+	if len(s.History) == 0 {
+		return nil
+	}
+	if err := SaveHistory(s.HistoryPath, s.History); err != nil {
+		return err
+	}
+	return s.UpdateSessionMetadata()
 }

--- a/internal/session/ttystyle.go
+++ b/internal/session/ttystyle.go
@@ -1,0 +1,63 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// colorize wraps a string with ANSI color codes if output is a TTY
+func colorize(s string, code string) string {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		return code + s + "\033[0m"
+	}
+	return s
+}
+
+// colorID returns the ID string with blue color if TTY
+func colorID(id string) string {
+	return colorize(id, "\033[36m")
+}
+
+// colorBold returns the string in bold if TTY
+func colorBold(s string) string {
+	return colorize(s, "\033[1m")
+}
+
+// truncateUTF8 safely truncates a string to maxLen runes, handling UTF-8 characters
+func truncateUTF8(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	// Use rune count for safe truncation
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
+// FormatSessionDisplay formats a session for display with appropriate styling
+func FormatSessionDisplay(meta SessionMeta) string {
+	var lines []string
+	lines = append(lines, colorID(fmt.Sprintf("ID: %s", strings.TrimSuffix(meta.ID, ".json"))))
+	lines = append(lines, fmt.Sprintf("    Title:   %s", meta.Title))
+	lines = append(lines, fmt.Sprintf("    Created: %s", meta.CreatedAt.Format("2006-01-02 15:04:05")))
+	lines = append(lines, fmt.Sprintf("    Updated: %s", meta.LastUpdated.Format("2006-01-02 15:04:05")))
+	lines = append(lines, fmt.Sprintf("    Msg #:   %d", meta.MessageCount))
+	if meta.LastUserPrompt != "" {
+		last := meta.LastUserPrompt
+		if len([]rune(last)) > 50 {
+			last = truncateUTF8(last, 50)
+		}
+		lines = append(lines, fmt.Sprintf("    Last:    %s", last))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// FormatResumePrompt formats the resume prompt with appropriate styling
+func FormatResumePrompt() string {
+	return colorBold("To resume, use: late session load <id>")
+}


### PR DESCRIPTION
## Context
This PR adds session persistence and management capabilities to the `late` CLI. Previously, all chat history was stored in a single `history.json` file, which meant that multiple invocations of `late` would overwrite each other’s state. Now, each session is saved in a timestamped directory (`.local/share/late/sessions/`) and can be resumed later using simple subcommands.

## Changes
- Introduced a new `session` subcommand with `list`, `load`, and `delete` actions.
- Each run now creates a new session file named `session-YYYYMMDD-HHMMSS.json`, ensuring full isolation.
- Session metadata (title, last prompt preview, message count) is persisted in a corresponding `.meta.json` file and used for human-readable session lists.
- All message additions (user, assistant, tool results) now atomically update both the history file and its metadata.