### PR TITLE
feat: Windows support and cross-platform compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-bin/late
+bin/
+build/
 implementation_plan.md
 pr_review_report.md

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -122,6 +123,10 @@ func main() {
 			map[string]string{
 				"${{NOTICE}}": "Bash is disabled. You must not attempt to use execute any bash commands. Doing so will result in an error.",
 			})
+	}
+
+	if runtime.GOOS == "windows" {
+		systemPrompt += "\n\n## Platform Note\nYou are running on **Windows** and commands execute in **PowerShell**. Prefer PowerShell-native commands and syntax:\n- Prefer `Get-ChildItem` (or `dir`) for directory listing\n- Prefer `Get-Content` for reading files\n- Prefer `Remove-Item` for deleting files/directories\n- Prefer `Copy-Item` and `Move-Item` for copy/move operations\n- Prefer `New-Item -ItemType Directory` for explicit directory creation\n- Use PowerShell quoting/escaping rules and avoid Unix-only shell syntax\n- Do NOT use bash/sh-specific features unless explicitly required"
 	}
 
 	if *appendSystemPromptReq != "" {

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -92,6 +92,7 @@ const (
 	InputProviderKey  contextKey = "input_provider"
 	OrchestratorIDKey contextKey = "orchestrator_id"
 	SkipConfirmationKey contextKey = "skip_confirmation"
+	ToolApprovalKey    contextKey = "tool_approval"
 )
 
 // GetInputProvider returns the InputProvider from the context.

--- a/internal/common/path_utils.go
+++ b/internal/common/path_utils.go
@@ -16,6 +16,7 @@ func LateConfigDir() (string, error) {
 
 func LateSessionDir() (string, error) {
 	if runtime.GOOS == "windows" {
+		// Use UserConfigDir on Windows to keep all app state under AppData.
 		configDir, err := LateConfigDir()
 		if err != nil {
 			return "", err
@@ -31,7 +32,7 @@ func LateSessionDir() (string, error) {
 }
 
 // LateProjectMCPConfigPath returns the relative project-local MCP config
-// location (".late/mcp_config.json"), to be resolved by the caller.
+// location (".late/mcp_config.json"), resolved relative to process CWD.
 func LateProjectMCPConfigPath() string {
 	return filepath.Join(".late", "mcp_config.json")
 }

--- a/internal/common/path_utils.go
+++ b/internal/common/path_utils.go
@@ -30,8 +30,8 @@ func LateSessionDir() (string, error) {
 	return filepath.Join(homeDir, ".local", "share", "late", "sessions"), nil
 }
 
-// LateProjectMCPConfigPath resolves the project-local MCP config path
-// relative to the current working directory.
+// LateProjectMCPConfigPath returns the project-local MCP config path.
+// The returned path is relative and is resolved by the caller.
 func LateProjectMCPConfigPath() string {
 	return filepath.Join(".late", "mcp_config.json")
 }

--- a/internal/common/path_utils.go
+++ b/internal/common/path_utils.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func LateConfigDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "late"), nil
+}
+
+func LateSessionDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		configDir, err := LateConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(configDir, "sessions"), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".local", "share", "late", "sessions"), nil
+}
+
+func LateProjectMCPConfigPath() string {
+	return filepath.Join(".late", "mcp_config.json")
+}
+
+func LateUserMCPConfigPath() (string, error) {
+	configDir, err := LateConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "mcp_config.json"), nil
+}

--- a/internal/common/path_utils.go
+++ b/internal/common/path_utils.go
@@ -30,8 +30,8 @@ func LateSessionDir() (string, error) {
 	return filepath.Join(homeDir, ".local", "share", "late", "sessions"), nil
 }
 
-// LateProjectMCPConfigPath returns the project-local MCP config path.
-// The returned path is relative and is resolved by the caller.
+// LateProjectMCPConfigPath returns the relative project-local MCP config
+// location (".late/mcp_config.json"), to be resolved by the caller.
 func LateProjectMCPConfigPath() string {
 	return filepath.Join(".late", "mcp_config.json")
 }

--- a/internal/common/path_utils.go
+++ b/internal/common/path_utils.go
@@ -17,11 +17,11 @@ func LateConfigDir() (string, error) {
 func LateSessionDir() (string, error) {
 	if runtime.GOOS == "windows" {
 		// Use UserConfigDir on Windows to keep all app state under AppData.
-		configDir, err := LateConfigDir()
+		lateConfigDir, err := LateConfigDir()
 		if err != nil {
 			return "", err
 		}
-		return filepath.Join(configDir, "sessions"), nil
+		return filepath.Join(lateConfigDir, "sessions"), nil
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -38,9 +38,9 @@ func LateProjectMCPConfigPath() string {
 }
 
 func LateUserMCPConfigPath() (string, error) {
-	configDir, err := LateConfigDir()
+	lateConfigDir, err := LateConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configDir, "mcp_config.json"), nil
+	return filepath.Join(lateConfigDir, "mcp_config.json"), nil
 }

--- a/internal/common/path_utils.go
+++ b/internal/common/path_utils.go
@@ -30,6 +30,8 @@ func LateSessionDir() (string, error) {
 	return filepath.Join(homeDir, ".local", "share", "late", "sessions"), nil
 }
 
+// LateProjectMCPConfigPath resolves the project-local MCP config path
+// relative to the current working directory.
 func LateProjectMCPConfigPath() string {
 	return filepath.Join(".late", "mcp_config.json")
 }

--- a/internal/common/path_utils_test.go
+++ b/internal/common/path_utils_test.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLateConfigDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("AppData", `C:\Users\Test\AppData\Roaming`)
+		t.Setenv("APPDATA", `C:\Users\Test\AppData\Roaming`)
+		got, err := LateConfigDir()
+		if err != nil {
+			t.Fatalf("LateConfigDir() error = %v", err)
+		}
+		want := filepath.Join(`C:\Users\Test\AppData\Roaming`, "late")
+		if got != want {
+			t.Fatalf("LateConfigDir() = %q, want %q", got, want)
+		}
+		return
+	}
+
+	t.Setenv("HOME", "/tmp/late-home")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	got, err := LateConfigDir()
+	if err != nil {
+		t.Fatalf("LateConfigDir() error = %v", err)
+	}
+	want := filepath.Join("/tmp/late-home", ".config", "late")
+	if got != want {
+		t.Fatalf("LateConfigDir() = %q, want %q", got, want)
+	}
+}
+
+func TestLateSessionDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Setenv("AppData", `C:\Users\Test\AppData\Roaming`)
+		t.Setenv("APPDATA", `C:\Users\Test\AppData\Roaming`)
+		got, err := LateSessionDir()
+		if err != nil {
+			t.Fatalf("LateSessionDir() error = %v", err)
+		}
+		want := filepath.Join(`C:\Users\Test\AppData\Roaming`, "late", "sessions")
+		if got != want {
+			t.Fatalf("LateSessionDir() = %q, want %q", got, want)
+		}
+		return
+	}
+
+	t.Setenv("HOME", "/tmp/late-home")
+	got, err := LateSessionDir()
+	if err != nil {
+		t.Fatalf("LateSessionDir() error = %v", err)
+	}
+	want := filepath.Join("/tmp/late-home", ".local", "share", "late", "sessions")
+	if got != want {
+		t.Fatalf("LateSessionDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"late/internal/common"
 	"os"
 	"path/filepath"
 )
@@ -12,12 +13,10 @@ type Config struct {
 }
 
 func LoadConfig() (*Config, error) {
-	configDir, err := os.UserConfigDir()
+	lateConfigDir, err := common.LateConfigDir()
 	if err != nil {
 		return nil, err
 	}
-
-	lateConfigDir := filepath.Join(configDir, "late")
 	configPath := filepath.Join(lateConfigDir, "config.json")
 
 	content, err := os.ReadFile(configPath)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -97,7 +97,7 @@ func RegisterTools(reg *tool.Registry, enabledTools map[string]bool, isPlanning 
 		reg.Register(tool.NewReadFileTool())
 	}
 	if enabledTools["bash"] {
-		reg.Register(tool.BashTool{})
+		reg.Register(tool.ShellTool{})
 	}
 
 	if isPlanning {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"late/internal/common"
 	"late/internal/session"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -175,6 +176,33 @@ func TestExecuteToolCalls_Denied(t *testing.T) {
 	}
 	if sess.History[0].Content != "Tool execution cancelled by user" {
 		t.Errorf("expected cancel message, got '%s'", sess.History[0].Content)
+	}
+}
+
+// TestExecuteToolCalls_NoMiddlewareFailsClosed verifies shell commands cannot
+// run when confirmation middleware is missing.
+func TestExecuteToolCalls_NoMiddlewareFailsClosed(t *testing.T) {
+	c := client.NewClient(client.Config{BaseURL: "http://localhost:0"})
+	histPath := filepath.Join(t.TempDir(), "history.json")
+	sess := session.New(c, histPath, nil, "", true)
+
+	RegisterTools(sess.Registry, map[string]bool{"bash": true}, false)
+
+	toolCalls := []client.ToolCall{
+		{ID: "tc_1", Function: client.FunctionCall{Name: "bash", Arguments: `{"command":"echo hi"}`}},
+	}
+
+	err := ExecuteToolCalls(context.Background(), sess, toolCalls, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(sess.History) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(sess.History))
+	}
+
+	if !strings.Contains(sess.History[0].Content, "requires explicit approval") {
+		t.Fatalf("expected fail-closed approval message, got %q", sess.History[0].Content)
 	}
 }
 

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"late/internal/common"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,13 +31,11 @@ func LoadMCPConfig() (*MCPConfig, error) {
 	}
 
 	if configPath == "" {
-		// Define default paths
-		configDir, err := os.UserConfigDir()
+		lateConfigDir, err := common.LateConfigDir()
 		if err != nil {
 			return &MCPConfig{McpServers: make(map[string]MCPServer)}, nil
 		}
 
-		lateConfigDir := filepath.Join(configDir, "late")
 		defaultUserPath := filepath.Join(lateConfigDir, "mcp_config.json")
 
 		// Pre-populate with a default config
@@ -57,18 +56,17 @@ func LoadMCPConfig() (*MCPConfig, error) {
 // findConfigPath searches for config files in order of precedence
 func findConfigPath() (string, error) {
 	// 1. Project-level: .late/mcp_config.json in current directory
-	projectPath := filepath.Join(".late", "mcp_config.json")
+	projectPath := common.LateProjectMCPConfigPath()
 	if _, err := os.Stat(projectPath); err == nil {
 		return projectPath, nil
 	}
 
-	// 2. User-level: ~/.config/late/mcp_config.json (using XDG UserConfigDir)
-	configDir, err := os.UserConfigDir()
+	// 2. User-level config path
+	userPath, err := common.LateUserMCPConfigPath()
 	if err != nil {
 		return "", fmt.Errorf("failed to get config directory: %w", err)
 	}
 
-	userPath := filepath.Join(configDir, "late", "mcp_config.json")
 	if _, err := os.Stat(userPath); err == nil {
 		return userPath, nil
 	}

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+	"late/internal/common"
 	"os"
 	"path/filepath"
 	"sort"
@@ -23,11 +24,7 @@ type SessionMeta struct {
 
 // SessionDir returns the directory where session metadata and histories are stored
 var SessionDir = func() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, ".local", "share", "late", "sessions"), nil
+	return common.LateSessionDir()
 }
 
 // SaveSessionMeta saves session metadata to the sessions directory

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -334,7 +334,7 @@ func (t *ShellTool) WrapError(ctx context.Context, err error) error {
 
 	var errorMsg string
 	if strings.Contains(strings.ToLower(orchestratorID), "coder") {
-		errorMsg = fmt.Sprintf("Do not use a %s command like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", shellDisplayName(), err.Error())
+		errorMsg = fmt.Sprintf("Do not use %s commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", shellDisplayName(), err.Error())
 	} else {
 		errorMsg = fmt.Sprintf("You are an architect/planner agent. You cannot write files. To modify files, you must spawn a coder subagent using `spawn_subagent` tool. %s", err.Error())
 	}

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -432,6 +433,15 @@ func (t ShellTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		return "", t.WrapError(ctx, err)
 	}
 
+	// Enforce approval in the execution path so shell commands fail closed
+	// even if middleware wiring is missing.
+	if t.RequiresConfirmation(args) {
+		approved, ok := ctx.Value(common.ToolApprovalKey).(bool)
+		if !ok || !approved {
+			return "", fmt.Errorf("shell command requires explicit approval before execution")
+		}
+	}
+
 	// Validate and set working directory
 	if params.Cwd != "" {
 		if !IsSafePath(params.Cwd) {
@@ -475,6 +485,11 @@ func (t ShellTool) RequiresConfirmation(args json.RawMessage) bool {
 		return true // Default to requiring confirmation if we can't parse
 	}
 
+	// Conservative Windows policy: always require confirmation.
+	if runtime.GOOS == "windows" {
+		return true
+	}
+
 	// If the command contains any shell metacharacters that could embed
 	// sub-commands or disguise intent, always require confirmation.
 	// This is the primary defense: we don't try to parse complex shell
@@ -500,11 +515,19 @@ func (t ShellTool) CallString(args json.RawMessage) string {
 		Cwd     string `json:"cwd"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
+		if runtime.GOOS == "windows" {
+			return "Executing in PowerShell: (invalid args)"
+		}
 		return "Executing: (invalid args)"
 	}
 
 	// Build the display string
-	result := fmt.Sprintf("Executing: %s", params.Command)
+	var result string
+	if runtime.GOOS == "windows" {
+		result = fmt.Sprintf("Executing in PowerShell: %s", params.Command)
+	} else {
+		result = fmt.Sprintf("Executing: %s", params.Command)
+	}
 	if params.Cwd != "" {
 		result += " in dir: " + params.Cwd
 	}

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -334,7 +334,7 @@ func (t *ShellTool) WrapError(ctx context.Context, err error) error {
 
 	var errorMsg string
 	if strings.Contains(strings.ToLower(orchestratorID), "coder") {
-		errorMsg = fmt.Sprintf("Do not use %s commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", shellDisplayName(), err.Error())
+		errorMsg = fmt.Sprintf("Do not use a %s command like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", shellDisplayName(), err.Error())
 	} else {
 		errorMsg = fmt.Sprintf("You are an architect/planner agent. You cannot write files. To modify files, you must spawn a coder subagent using `spawn_subagent` tool. %s", err.Error())
 	}

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -334,7 +334,7 @@ func (t *ShellTool) WrapError(ctx context.Context, err error) error {
 
 	var errorMsg string
 	if strings.Contains(strings.ToLower(orchestratorID), "coder") {
-		errorMsg = fmt.Sprintf("Do not use host-native shell commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", err.Error())
+		errorMsg = fmt.Sprintf("Do not use %s commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", shellDisplayName(), err.Error())
 	} else {
 		errorMsg = fmt.Sprintf("You are an architect/planner agent. You cannot write files. To modify files, you must spawn a coder subagent using `spawn_subagent` tool. %s", err.Error())
 	}
@@ -405,19 +405,26 @@ func getAllBaseCommands(command string) []string {
 // ShellTool executes host-native shell commands with security restrictions.
 type ShellTool struct{}
 
+func shellDisplayName() string {
+	if runtime.GOOS == "windows" {
+		return "PowerShell"
+	}
+	return "bash"
+}
+
 func (t ShellTool) Name() string { return "bash" }
 func (t ShellTool) Description() string {
-	return "Execute host-native shell commands."
+	return fmt.Sprintf("Execute a %s command.", shellDisplayName())
 }
 func (t ShellTool) Parameters() json.RawMessage {
-	return json.RawMessage(`{
+	return json.RawMessage(fmt.Sprintf(`{
 		"type": "object",
 		"properties": {
-			"command": { "type": "string", "description": "The full host-native shell command to execute." },
+			"command": { "type": "string", "description": "The full %s command to execute." },
 			"cwd": { "type": "string", "description": "Working directory for execution. Use this instead of 'cd' commands to change directories." }
 		},
 		"required": ["command"]
-	}`)
+	}`, shellDisplayName()))
 }
 func (t ShellTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -241,42 +241,42 @@ func isMaliciousCatCommand(command string) (bool, error) {
 	// Pattern to detect cat with output redirection (>)
 	// Matches: cat > file, cat >> file, cat 2> file, echo | cat > file, etc.
 	// Does NOT match: cat file.txt (reading), cat < file.txt (input redirection), cat file | grep (piping)
-	
+
 	// First, strip comments and quotes to avoid false positives
 	cleanCmd := command
 	// Remove single-line comments
 	if idx := strings.Index(cleanCmd, "#"); idx != -1 {
 		cleanCmd = cleanCmd[:idx]
 	}
-	
+
 	// Pattern explanation:
 	// - Match "cat" command (possibly with whitespace before it)
 	// - Followed by output redirection (>, >>, 2>)
 	// - The redirection must be a standalone redirection, not part of a pipe
-	
+
 	// This regex matches:
 	// - cat followed by whitespace and > (output redirection)
 	// - cat followed by whitespace and >> (append redirection)
 	// - cat followed by 2> (stderr redirection)
 	// - | cat followed by whitespace and > (pipe to cat with output redirection)
 	maliciousPatterns := []string{
-		`(?i)\bcat\s+>>\s+`,            // cat >> file
-		`(?i)\bcat\s+>\s+`,             // cat > file
-		`(?i)\bcat\s+2>\s+`,            // cat 2> file
-		`(?i)\|\s*cat\s+>\s+`,          // | cat > file
-		`(?i)\|\s*cat\s+>>\s+`,         // | cat >> file
-		`(?i)\|\s*cat\s+2>\s+`,         // | cat 2> file
-		`(?i)cat\s+\d+\s*>`,            // cat 0> file, cat 1> file, cat 1 > file, etc.
-		`(?i)\|\s*cat\s+\d+\s*>`,       // | cat 1> file
+		`(?i)\bcat\s+>>\s+`,      // cat >> file
+		`(?i)\bcat\s+>\s+`,       // cat > file
+		`(?i)\bcat\s+2>\s+`,      // cat 2> file
+		`(?i)\|\s*cat\s+>\s+`,    // | cat > file
+		`(?i)\|\s*cat\s+>>\s+`,   // | cat >> file
+		`(?i)\|\s*cat\s+2>\s+`,   // | cat 2> file
+		`(?i)cat\s+\d+\s*>`,      // cat 0> file, cat 1> file, cat 1 > file, etc.
+		`(?i)\|\s*cat\s+\d+\s*>`, // | cat 1> file
 	}
-	
+
 	for _, pattern := range maliciousPatterns {
 		re := regexp.MustCompile(pattern)
 		if re.MatchString(cleanCmd) {
 			return true, fmt.Errorf("cat cannot be used with output redirection (>) to write files")
 		}
 	}
-	
+
 	return false, nil
 }
 
@@ -289,7 +289,7 @@ func isCdCommand(command string) (bool, error) {
 	if idx := strings.Index(cleanCmd, "#"); idx != -1 {
 		cleanCmd = cleanCmd[:idx]
 	}
-	
+
 	// Pattern explanation:
 	// - Optional leading whitespace
 	// - "cd" as a standalone word (not part of another word like cd_log or mkdir)
@@ -297,11 +297,11 @@ func isCdCommand(command string) (bool, error) {
 	// - The \b word boundary ensures we match "cd" but not "cd_log" or "mkdir"
 	pattern := `^\s*cd\s+`
 	re := regexp.MustCompile(pattern)
-	
+
 	if re.MatchString(cleanCmd) {
 		return true, fmt.Errorf("Do not use `cd` to change directories. Use the `cwd` parameter in the bash tool instead.")
 	}
-	
+
 	return false, nil
 }
 
@@ -313,13 +313,13 @@ func (t *BashTool) ValidateBashCommand(command string) error {
 	if isMalicious {
 		return err
 	}
-	
+
 	// Check for cd commands
 	isCd, err := isCdCommand(command)
 	if isCd {
 		return err
 	}
-	
+
 	return nil
 }
 
@@ -330,14 +330,14 @@ func (t *BashTool) WrapError(ctx context.Context, err error) error {
 	}
 
 	orchestratorID := common.GetOrchestratorID(ctx)
-	
+
 	var errorMsg string
 	if strings.Contains(strings.ToLower(orchestratorID), "coder") {
 		errorMsg = fmt.Sprintf("Do not use bash commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", err.Error())
 	} else {
 		errorMsg = fmt.Sprintf("You are an architect/planner agent. You cannot write files. To modify files, you must spawn a coder subagent using `spawn_subagent` tool. %s", err.Error())
 	}
-	
+
 	return fmt.Errorf("%s", errorMsg)
 }
 
@@ -349,13 +349,13 @@ func (t *BashTool) IsCommandBlocked(command string) (bool, error) {
 	if isCd {
 		return true, err
 	}
-	
+
 	// Block cat with output redirection immediately
 	isMalicious, err := isMaliciousCatCommand(command)
 	if isMalicious {
 		return true, err
 	}
-	
+
 	return false, nil
 }
 
@@ -365,7 +365,9 @@ func (t *BashTool) IsCommandBlocked(command string) (bool, error) {
 //
 // Note: This function does NOT handle quoted strings or subshells.
 // For example: echo 'hello && goodbye' ; ls  → ["echo", "goodbye'", "ls"]
-//              echo foo; (cd /tmp && ls)      → ["echo", "(cd", "ls"]
+//
+//	echo foo; (cd /tmp && ls)      → ["echo", "(cd", "ls"]
+//
 // These edge cases currently cause over-confirmation (safer than under-confirmation).
 func getAllBaseCommands(command string) []string {
 	var commands = []string{}
@@ -445,8 +447,8 @@ func (t BashTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 		params.Cwd = cwd
 	}
 
-	// Execute the command using bash -c to handle parsing correctly
-	cmd := exec.CommandContext(ctx, "bash", "-c", params.Command)
+	// Execute command using a platform-specific shell wrapper.
+	cmd := newShellCommand(ctx, params.Command)
 	cmd.Dir = params.Cwd
 
 	output, err := cmd.CombinedOutput()

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -364,8 +364,9 @@ func (t *BashTool) IsCommandBlocked(command string) (bool, error) {
 // For example: "echo foo; wget url | cat" returns ["echo", "wget", "cat"]
 //
 // Note: This function does NOT handle quoted strings or subshells.
-// For example: echo 'hello && goodbye' ; ls  → ["echo", "goodbye'", "ls"]
-// For example: echo foo; (cd /tmp && ls)      → ["echo", "(cd", "ls"]
+// Examples:
+// - echo 'hello && goodbye' ; ls  → ["echo", "goodbye'", "ls"]
+// - echo foo; (cd /tmp && ls)     → ["echo", "(cd", "ls"]
 // These edge cases currently cause over-confirmation (safer than under-confirmation).
 func getAllBaseCommands(command string) []string {
 	var commands = []string{}

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -170,7 +170,7 @@ func (t WriteFileTool) CallString(args json.RawMessage) string {
 	return fmt.Sprintf("Writing to file %s", truncate(path, 50))
 }
 
-// Commands that do not require user confirmation for BashTool.
+// Commands that do not require user confirmation for ShellTool.
 // Only genuinely read-only commands belong here.
 var whitelistedCommands = map[string]bool{
 	"grep":   true,
@@ -192,7 +192,7 @@ var whitelistedCommands = map[string]bool{
 // regardless of the base command, because we cannot trust our naive
 // string-split parsing to extract the real commands from the string.
 func containsShellMetacharacters(command string) bool {
-	// Newline / carriage return / NUL: bash -c treats these as command
+	// Newline / carriage return / NUL: shell -c treats these as command
 	// separators, and our base-command extractor does not split on them.
 	// Without this check, `grep foo\n<payload>` auto-approves on the
 	// basis of `grep` alone.
@@ -280,7 +280,7 @@ func isMaliciousCatCommand(command string) (bool, error) {
 	return false, nil
 }
 
-// isCdCommand detects when a bash command contains `cd` to change directories.
+// isCdCommand detects when a shell command contains `cd` to change directories.
 // Returns true if the command attempts to change directories, false if safe.
 // Returns an error with instructions on using the `cwd` parameter instead.
 func isCdCommand(command string) (bool, error) {
@@ -299,15 +299,15 @@ func isCdCommand(command string) (bool, error) {
 	re := regexp.MustCompile(pattern)
 
 	if re.MatchString(cleanCmd) {
-		return true, fmt.Errorf("Do not use `cd` to change directories. Use the `cwd` parameter in the bash tool instead.")
+		return true, fmt.Errorf("Do not use `cd` to change directories. Use the `cwd` parameter in the shell tool instead.")
 	}
 
 	return false, nil
 }
 
-// ValidateBashCommand validates bash commands before execution.
+// ValidateBashCommand validates shell commands before execution.
 // Returns an error if the command uses malicious patterns like cat shenanigans or cd commands.
-func (t *BashTool) ValidateBashCommand(command string) error {
+func (t *ShellTool) ValidateBashCommand(command string) error {
 	// Check for malicious cat commands
 	isMalicious, err := isMaliciousCatCommand(command)
 	if isMalicious {
@@ -324,7 +324,7 @@ func (t *BashTool) ValidateBashCommand(command string) error {
 }
 
 // WrapError wraps a validation error with descriptive guidance based on the orchestrator ID.
-func (t *BashTool) WrapError(ctx context.Context, err error) error {
+func (t *ShellTool) WrapError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -333,7 +333,7 @@ func (t *BashTool) WrapError(ctx context.Context, err error) error {
 
 	var errorMsg string
 	if strings.Contains(strings.ToLower(orchestratorID), "coder") {
-		errorMsg = fmt.Sprintf("Do not use bash commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", err.Error())
+		errorMsg = fmt.Sprintf("Do not use host-native shell commands like `cat > file` or `echo > file` to write files. Use the native `write_file` or `target_edit` tools instead. %s", err.Error())
 	} else {
 		errorMsg = fmt.Sprintf("You are an architect/planner agent. You cannot write files. To modify files, you must spawn a coder subagent using `spawn_subagent` tool. %s", err.Error())
 	}
@@ -341,9 +341,9 @@ func (t *BashTool) WrapError(ctx context.Context, err error) error {
 	return fmt.Errorf("%s", errorMsg)
 }
 
-// IsCommandBlocked checks if a bash command should be blocked entirely (not asked for confirmation).
+// IsCommandBlocked checks if a shell command should be blocked entirely (not asked for confirmation).
 // Returns true and an error if the command is blocked (e.g., cd commands).
-func (t *BashTool) IsCommandBlocked(command string) (bool, error) {
+func (t *ShellTool) IsCommandBlocked(command string) (bool, error) {
 	// Block cd commands immediately - they should never be confirmed, only rejected
 	isCd, err := isCdCommand(command)
 	if isCd {
@@ -359,7 +359,7 @@ func (t *BashTool) IsCommandBlocked(command string) (bool, error) {
 	return false, nil
 }
 
-// getAllBaseCommands splits a compound bash command into individual segments
+// getAllBaseCommands splits a compound shell command into individual segments
 // and extracts the base command (first word) from each segment.
 // For example: "echo foo; wget url | cat" returns ["echo", "wget", "cat"]
 //
@@ -401,24 +401,24 @@ func getAllBaseCommands(command string) []string {
 	return commands
 }
 
-// BashTool executes a bash command with security restrictions.
-type BashTool struct{}
+// ShellTool executes host-native shell commands with security restrictions.
+type ShellTool struct{}
 
-func (t BashTool) Name() string { return "bash" }
-func (t BashTool) Description() string {
-	return "Execute a bash command."
+func (t ShellTool) Name() string { return "bash" }
+func (t ShellTool) Description() string {
+	return "Execute host-native shell commands."
 }
-func (t BashTool) Parameters() json.RawMessage {
+func (t ShellTool) Parameters() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
-			"command": { "type": "string", "description": "The full command to execute." },
+			"command": { "type": "string", "description": "The full host-native shell command to execute." },
 			"cwd": { "type": "string", "description": "Working directory for execution. Use this instead of 'cd' commands to change directories." }
 		},
 		"required": ["command"]
 	}`)
 }
-func (t BashTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+func (t ShellTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
 		Command string `json:"command"`
 		Cwd     string `json:"cwd"`
@@ -467,7 +467,7 @@ func (t BashTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 	return strings.Join(lines, "\n"), nil
 }
-func (t BashTool) RequiresConfirmation(args json.RawMessage) bool {
+func (t ShellTool) RequiresConfirmation(args json.RawMessage) bool {
 	var params struct {
 		Command string `json:"command"`
 	}
@@ -494,7 +494,7 @@ func (t BashTool) RequiresConfirmation(args json.RawMessage) bool {
 	return false
 }
 
-func (t BashTool) CallString(args json.RawMessage) string {
+func (t ShellTool) CallString(args json.RawMessage) string {
 	var params struct {
 		Command string `json:"command"`
 		Cwd     string `json:"cwd"`

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -365,9 +365,7 @@ func (t *BashTool) IsCommandBlocked(command string) (bool, error) {
 //
 // Note: This function does NOT handle quoted strings or subshells.
 // For example: echo 'hello && goodbye' ; ls  → ["echo", "goodbye'", "ls"]
-//
-//	echo foo; (cd /tmp && ls)      → ["echo", "(cd", "ls"]
-//
+// For example: echo foo; (cd /tmp && ls)      → ["echo", "(cd", "ls"]
 // These edge cases currently cause over-confirmation (safer than under-confirmation).
 func getAllBaseCommands(command string) []string {
 	var commands = []string{}

--- a/internal/tool/implementations_bash_test.go
+++ b/internal/tool/implementations_bash_test.go
@@ -175,7 +175,7 @@ func TestValidateBashCommand(t *testing.T) {
 		},
 	}
 
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -279,7 +279,7 @@ func TestValidateBashCommandEdgeCases(t *testing.T) {
 		},
 	}
 
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -414,7 +414,7 @@ func TestIsCdCommand_NonCdCommands(t *testing.T) {
 
 // TestValidateBashCommand_Comprehensive tests comprehensive validation scenarios
 func TestValidateBashCommand_Comprehensive(t *testing.T) {
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Test all malicious cat patterns
 	maliciousPatterns := []string{
@@ -498,7 +498,7 @@ func TestValidateBashCommand_Comprehensive(t *testing.T) {
 
 // TestValidateBashCommand_ErrorMessages tests that error messages are informative
 func TestValidateBashCommand_ErrorMessages(t *testing.T) {
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Test cd command error message
 	err := tool.ValidateBashCommand("cd /tmp")
@@ -537,9 +537,9 @@ func contains(s, substr string) bool {
 // TestGetAllBaseCommands tests the getAllBaseCommands helper function
 func TestGetAllBaseCommands(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		want   []string
+		name  string
+		input string
+		want  []string
 	}{
 		{"simple command", "wget url", []string{"wget"}},
 		{"semicolon compound", "echo foo; wget url", []string{"echo", "wget"}},

--- a/internal/tool/implementations_cmd_test.go
+++ b/internal/tool/implementations_cmd_test.go
@@ -1,0 +1,140 @@
+//go:build windows
+
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"late/internal/common"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf16"
+	"encoding/base64"
+)
+
+// getUnixShellPath is a shim so shell_command_test.go (which references this symbol)
+// compiles on Windows without modification.
+func getUnixShellPath() string {
+	return "powershell.exe"
+}
+
+func approvedContextForCmdTests() context.Context {
+	return context.WithValue(context.Background(), common.ToolApprovalKey, true)
+}
+
+// decodePSCommand reverses encodePSCommand for test assertions.
+func decodePSCommand(encoded string) string {
+	b, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return ""
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = uint16(b[i*2]) | uint16(b[i*2+1])<<8
+	}
+	runes := utf16.Decode(u16)
+	return string(runes)
+}
+
+func TestPSShellCommand_UsesPowerShell(t *testing.T) {
+	cmd := newShellCommand(context.Background(), "echo test")
+	base := strings.ToLower(filepath.Base(cmd.Path))
+	if base != "pwsh.exe" && base != "powershell.exe" {
+		t.Fatalf("expected pwsh.exe or powershell.exe, got %q", cmd.Path)
+	}
+}
+
+func TestPSShellCommand_HasRequiredFlags(t *testing.T) {
+	cmd := newShellCommand(context.Background(), "echo test")
+	args := strings.Join(cmd.Args, " ")
+	for _, flag := range []string{"-NoProfile", "-NonInteractive", "-EncodedCommand"} {
+		if !strings.Contains(args, flag) {
+			t.Errorf("expected flag %q in args %q", flag, args)
+		}
+	}
+}
+
+func TestPSShellCommand_EncodedCommandDecodesCorrectly(t *testing.T) {
+	cases := []string{
+		"dir",
+		`Get-ChildItem 'C:\Users\jmorales\my project'`,
+		`Write-Output 'hello world'`,
+		"Get-Content file.txt | Select-String pattern",
+	}
+	for _, command := range cases {
+		cmd := newShellCommand(context.Background(), command)
+		// -EncodedCommand is the last-1 arg
+		args := cmd.Args
+		var encodedArg string
+		for i, a := range args {
+			if strings.EqualFold(a, "-EncodedCommand") && i+1 < len(args) {
+				encodedArg = args[i+1]
+				break
+			}
+		}
+		if encodedArg == "" {
+			t.Fatalf("no -EncodedCommand arg found for %q", command)
+		}
+		decoded := decodePSCommand(encodedArg)
+		if decoded != command {
+			t.Errorf("round-trip mismatch: got %q, want %q", decoded, command)
+		}
+	}
+}
+
+func TestPSShellTool_WindowsAlwaysRequiresConfirmation(t *testing.T) {
+	tool := ShellTool{}
+	cases := []json.RawMessage{
+		json.RawMessage(`{"command":"dir"}`),
+		json.RawMessage(`{"command":"Get-ChildItem"}`),
+		json.RawMessage(`{"command":"echo hello"}`),
+	}
+	for _, args := range cases {
+		if !tool.RequiresConfirmation(args) {
+			t.Fatalf("expected RequiresConfirmation=true on Windows for %s", string(args))
+		}
+	}
+}
+
+func TestPSShellTool_ExecuteFailsWithoutApproval(t *testing.T) {
+	tool := ShellTool{}
+	args := json.RawMessage(`{"command":"echo hello"}`)
+	_, err := tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected missing approval error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires explicit approval") {
+		t.Fatalf("expected approval error, got %q", err.Error())
+	}
+}
+
+func TestPSShellTool_ExecuteSucceedsWithApproval(t *testing.T) {
+	tool := ShellTool{}
+	args := json.RawMessage(`{"command":"Write-Output hello"}`)
+	out, err := tool.Execute(approvedContextForCmdTests(), args)
+	if err != nil {
+		t.Fatalf("approved execution failed: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "hello") {
+		t.Fatalf("expected output to contain hello, got %q", out)
+	}
+}
+
+func TestPSShellTool_CallString(t *testing.T) {
+	tool := ShellTool{}
+
+	cases := []struct {
+		args     json.RawMessage
+		wantPfx  string
+	}{
+		{json.RawMessage(`{"command":"Get-ChildItem"}`), "Executing in PowerShell: Get-ChildItem"},
+		{json.RawMessage(`{"command":"Write-Output hello","cwd":"C:/tmp"}`), "Executing in PowerShell: Write-Output hello in dir: C:/tmp"},
+	}
+	for _, c := range cases {
+		got := tool.CallString(c.args)
+		if got != c.wantPfx {
+			t.Errorf("CallString() = %q, want %q", got, c.wantPfx)
+		}
+	}
+}

--- a/internal/tool/implementations_test.go
+++ b/internal/tool/implementations_test.go
@@ -4,16 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"late/internal/common"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func approvedContext() context.Context {
+	return context.WithValue(context.Background(), common.ToolApprovalKey, true)
+}
 
 func TestReadFileTool_PartialRead(t *testing.T) {
 	// constant setup
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test.txt")
+		filePath = filepath.ToSlash(filePath)
 	content := "line1\nline2\nline3\nline4\nline5\n"
 	err := os.WriteFile(filePath, []byte(content), 0644)
 	if err != nil {
@@ -48,6 +55,7 @@ func TestReadFileTool_PartialRead(t *testing.T) {
 func TestReadFileTool_NoCaching(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test.txt")
+	filePath = filepath.ToSlash(filePath)
 	content := "unchanged content"
 	os.WriteFile(filePath, []byte(content), 0644)
 
@@ -92,6 +100,7 @@ func TestReadFileTool_NoCaching(t *testing.T) {
 func TestReadFileTool_OutputTruncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "large_test.txt")
+	filePath = filepath.ToSlash(filePath)
 
 	// Generate a file that exceeds maxReadFileChars
 	var sb strings.Builder
@@ -120,6 +129,9 @@ func TestReadFileTool_OutputTruncation(t *testing.T) {
 }
 
 func TestBashTool_Execute(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix echo/pwd behavior tests skipped on Windows; see TestPSShellTool_* in implementations_cmd_test.go")
+		}
 	tests := []struct {
 		name    string
 		params  json.RawMessage
@@ -167,7 +179,7 @@ func TestBashTool_Execute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tool := ShellTool{}
-			out, err := tool.Execute(context.Background(), tt.params)
+			out, err := tool.Execute(approvedContext(), tt.params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -186,6 +198,9 @@ func TestBashTool_Execute(t *testing.T) {
 }
 
 func TestBashTool_CWDParameter(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix pwd/path tests skipped on Windows")
+		}
 	// Create a subdirectory within the current working directory
 	// Use a subdirectory of the package directory to ensure it's within allowed paths
 	tmpDir := filepath.Join("internal", "tool", "test_cwd")
@@ -199,7 +214,7 @@ func TestBashTool_CWDParameter(t *testing.T) {
 
 	// Test with custom cwd
 	params := json.RawMessage(fmt.Sprintf(`{"command": "pwd", "cwd": "%s"}`, tmpDir))
-	out, err := tool.Execute(context.Background(), params)
+	out, err := tool.Execute(approvedContext(), params)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -209,11 +224,14 @@ func TestBashTool_CWDParameter(t *testing.T) {
 }
 
 func TestBashTool_MultipleArgs(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix echo multi-arg test skipped on Windows; see TestPSShellTool_* in implementations_cmd_test.go")
+		}
 	tool := ShellTool{}
 
 	// Test with multiple arguments
 	params := json.RawMessage(`{"command": "echo arg1 arg2 arg3"}`)
-	out, err := tool.Execute(context.Background(), params)
+	out, err := tool.Execute(approvedContext(), params)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -227,12 +245,15 @@ func TestBashTool_MultipleArgs(t *testing.T) {
 }
 
 func TestBashTool_OutputTruncation(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("seq command not available on Windows")
+		}
 	tool := ShellTool{}
 
 	// Create a command that outputs more than 1024 lines
 	// Using seq to generate numbers 1-2000
 	params := json.RawMessage(`{"command": "seq 1 2000"}`)
-	out, err := tool.Execute(context.Background(), params)
+	out, err := tool.Execute(approvedContext(), params)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -250,12 +271,15 @@ func TestBashTool_OutputTruncation(t *testing.T) {
 }
 
 func TestBashTool_UnsafeCWD(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix /tmp path test skipped on Windows")
+		}
 	tool := ShellTool{}
 
 	// Try to use an unsafe cwd (outside CWD)
 	// This should fail if we're not running from root
 	params := json.RawMessage(`{"command": "pwd", "cwd": "/tmp"}`)
-	out, err := tool.Execute(context.Background(), params)
+	out, err := tool.Execute(approvedContext(), params)
 
 	// The test depends on where we're running from
 	// If /tmp is within CWD, this should succeed
@@ -281,7 +305,7 @@ func TestBashTool_DefaultCWD(t *testing.T) {
 
 	// Execute without cwd parameter - should use current directory
 	params := json.RawMessage(`{"command": "pwd"}`)
-	out, err := tool.Execute(context.Background(), params)
+	out, err := tool.Execute(approvedContext(), params)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -298,6 +322,9 @@ func TestBashTool_DefaultCWD(t *testing.T) {
 }
 
 func TestBashTool_CallString(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix CallString prefix tested on Windows via TestPSShellTool_CallString in implementations_cmd_test.go")
+	}
 	tests := []struct {
 		name     string
 		params   json.RawMessage
@@ -486,6 +513,28 @@ func TestBashTool_ValidationMessages(t *testing.T) {
 	}
 }
 
+func TestBashTool_ExecuteRequiresApproval(t *testing.T) {
+	tool := ShellTool{}
+	params := json.RawMessage(`{"command": "echo hello"}`)
+
+	_, err := tool.Execute(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected missing-approval error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires explicit approval") {
+		t.Fatalf("expected approval error message, got %q", err.Error())
+	}
+
+	// Approved execution should proceed.
+	out, err := tool.Execute(approvedContext(), params)
+	if err != nil {
+		t.Fatalf("approved execution failed: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Fatalf("expected output to contain hello, got %q", out)
+	}
+}
+
 func TestBashTool_RequiresConfirmation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -626,9 +675,32 @@ func TestBashTool_RequiresConfirmation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tool := ShellTool{}
 			result := tool.RequiresConfirmation(tt.params)
-			if result != tt.expected {
-				t.Errorf("RequiresConfirmation(%s) = %v, want %v", string(tt.params), result, tt.expected)
+			expected := tt.expected
+			if runtime.GOOS == "windows" {
+				expected = true
+			}
+			if result != expected {
+				t.Errorf("RequiresConfirmation(%s) = %v, want %v", string(tt.params), result, expected)
 			}
 		})
+	}
+}
+
+func TestBashTool_RequiresConfirmation_WindowsAlwaysPrompt(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only safety policy")
+	}
+
+	tool := ShellTool{}
+	commands := []json.RawMessage{
+		json.RawMessage(`{"command": "pwd"}`),
+		json.RawMessage(`{"command": "cat file.txt | grep hello"}`),
+		json.RawMessage(`{"command": "ls"}`),
+	}
+
+	for _, args := range commands {
+		if !tool.RequiresConfirmation(args) {
+			t.Fatalf("expected RequiresConfirmation=true on Windows for %s", string(args))
+		}
 	}
 }

--- a/internal/tool/implementations_test.go
+++ b/internal/tool/implementations_test.go
@@ -166,7 +166,7 @@ func TestBashTool_Execute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool := BashTool{}
+			tool := ShellTool{}
 			out, err := tool.Execute(context.Background(), tt.params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
@@ -195,7 +195,7 @@ func TestBashTool_CWDParameter(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Test with custom cwd
 	params := json.RawMessage(fmt.Sprintf(`{"command": "pwd", "cwd": "%s"}`, tmpDir))
@@ -209,7 +209,7 @@ func TestBashTool_CWDParameter(t *testing.T) {
 }
 
 func TestBashTool_MultipleArgs(t *testing.T) {
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Test with multiple arguments
 	params := json.RawMessage(`{"command": "echo arg1 arg2 arg3"}`)
@@ -227,7 +227,7 @@ func TestBashTool_MultipleArgs(t *testing.T) {
 }
 
 func TestBashTool_OutputTruncation(t *testing.T) {
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Create a command that outputs more than 1024 lines
 	// Using seq to generate numbers 1-2000
@@ -250,7 +250,7 @@ func TestBashTool_OutputTruncation(t *testing.T) {
 }
 
 func TestBashTool_UnsafeCWD(t *testing.T) {
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Try to use an unsafe cwd (outside CWD)
 	// This should fail if we're not running from root
@@ -277,7 +277,7 @@ func TestBashTool_UnsafeCWD(t *testing.T) {
 }
 
 func TestBashTool_DefaultCWD(t *testing.T) {
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Execute without cwd parameter - should use current directory
 	params := json.RawMessage(`{"command": "pwd"}`)
@@ -327,7 +327,7 @@ func TestBashTool_CallString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool := BashTool{}
+			tool := ShellTool{}
 			result := tool.CallString(tt.params)
 			if result != tt.expected {
 				t.Errorf("CallString() = %q, want %q", result, tt.expected)
@@ -431,7 +431,7 @@ func TestBashTool_MaliciousCatCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool := BashTool{}
+			tool := ShellTool{}
 			err := tool.ValidateBashCommand(tt.command)
 
 			if tt.shouldBlock {
@@ -451,7 +451,7 @@ func TestBashTool_MaliciousCatCommands(t *testing.T) {
 
 func TestBashTool_ValidationMessages(t *testing.T) {
 	// Test that error messages are helpful and guide agents
-	tool := BashTool{}
+	tool := ShellTool{}
 
 	// Test blocked command
 	err := tool.ValidateBashCommand("cat > test.txt")
@@ -624,7 +624,7 @@ func TestBashTool_RequiresConfirmation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool := BashTool{}
+			tool := ShellTool{}
 			result := tool.RequiresConfirmation(tt.params)
 			if result != tt.expected {
 				t.Errorf("RequiresConfirmation(%s) = %v, want %v", string(tt.params), result, tt.expected)

--- a/internal/tool/shell_command_test.go
+++ b/internal/tool/shell_command_test.go
@@ -1,31 +1,14 @@
+//go:build !windows
+
 package tool
 
 import (
 	"context"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 )
 
 func TestNewShellCommand(t *testing.T) {
 	cmd := newShellCommand(context.Background(), "echo test")
-
-	if runtime.GOOS == "windows" {
-		if !strings.EqualFold(filepath.Base(cmd.Path), "cmd.exe") {
-			t.Fatalf("expected cmd.Path to end with cmd.exe, got %q", cmd.Path)
-		}
-		if len(cmd.Args) < 3 {
-			t.Fatalf("expected at least 3 args for windows shell command, got %v", cmd.Args)
-		}
-		if cmd.Args[1] != "/C" {
-			t.Fatalf("expected cmd.Args[1] to be /C, got %q", cmd.Args[1])
-		}
-		if cmd.Args[2] != "echo test" {
-			t.Fatalf("expected cmd.Args[2] to be original command, got %q", cmd.Args[2])
-		}
-		return
-	}
 
 	expectedShell := getUnixShellPath()
 	if cmd.Path != expectedShell {

--- a/internal/tool/shell_command_test.go
+++ b/internal/tool/shell_command_test.go
@@ -1,0 +1,43 @@
+package tool
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewShellCommand(t *testing.T) {
+	cmd := newShellCommand(context.Background(), "echo test")
+
+	if runtime.GOOS == "windows" {
+		if !strings.EqualFold(filepath.Base(cmd.Path), "cmd.exe") {
+			t.Fatalf("expected cmd.Path to end with cmd.exe, got %q", cmd.Path)
+		}
+		if len(cmd.Args) < 3 {
+			t.Fatalf("expected at least 3 args for windows shell command, got %v", cmd.Args)
+		}
+		if cmd.Args[1] != "/C" {
+			t.Fatalf("expected cmd.Args[1] to be /C, got %q", cmd.Args[1])
+		}
+		if cmd.Args[2] != "echo test" {
+			t.Fatalf("expected cmd.Args[2] to be original command, got %q", cmd.Args[2])
+		}
+		return
+	}
+
+	expectedShell := getUnixShellPath()
+	if cmd.Path != expectedShell {
+		t.Fatalf("expected cmd.Path %q, got %q", expectedShell, cmd.Path)
+	}
+	if len(cmd.Args) < 3 {
+		t.Fatalf("expected at least 3 args for unix shell command, got %v", cmd.Args)
+	}
+	if cmd.Args[1] != "-c" {
+		t.Fatalf("expected cmd.Args[1] to be -c, got %q", cmd.Args[1])
+	}
+	if cmd.Args[2] != "echo test" {
+		t.Fatalf("expected cmd.Args[2] to be original command, got %q", cmd.Args[2])
+	}
+}

--- a/internal/tool/shell_command_unix.go
+++ b/internal/tool/shell_command_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package tool
+
+import (
+	"context"
+	"os/exec"
+)
+
+func newShellCommand(ctx context.Context, command string) *exec.Cmd {
+	return exec.CommandContext(ctx, "bash", "-c", command)
+}

--- a/internal/tool/shell_command_unix.go
+++ b/internal/tool/shell_command_unix.go
@@ -5,12 +5,24 @@ package tool
 import (
 	"context"
 	"os/exec"
+	"sync"
 )
 
+var (
+	unixShellPath     string
+	unixShellPathOnce sync.Once
+)
+
+func detectedUnixShellPath() string {
+	unixShellPathOnce.Do(func() {
+		unixShellPath = "bash"
+		if _, err := exec.LookPath(unixShellPath); err != nil {
+			unixShellPath = "sh"
+		}
+	})
+	return unixShellPath
+}
+
 func newShellCommand(ctx context.Context, command string) *exec.Cmd {
-	shell := "bash"
-	if _, err := exec.LookPath(shell); err != nil {
-		shell = "sh"
-	}
-	return exec.CommandContext(ctx, shell, "-c", command)
+	return exec.CommandContext(ctx, detectedUnixShellPath(), "-c", command)
 }

--- a/internal/tool/shell_command_unix.go
+++ b/internal/tool/shell_command_unix.go
@@ -8,5 +8,9 @@ import (
 )
 
 func newShellCommand(ctx context.Context, command string) *exec.Cmd {
-	return exec.CommandContext(ctx, "bash", "-c", command)
+	shell := "bash"
+	if _, err := exec.LookPath(shell); err != nil {
+		shell = "sh"
+	}
+	return exec.CommandContext(ctx, shell, "-c", command)
 }

--- a/internal/tool/shell_command_unix.go
+++ b/internal/tool/shell_command_unix.go
@@ -15,10 +15,15 @@ var (
 
 func getUnixShellPath() string {
 	unixShellPathOnce.Do(func() {
-		unixShellPath = "bash"
-		if _, err := exec.LookPath(unixShellPath); err != nil {
-			unixShellPath = "sh"
+		if shellPath, err := exec.LookPath("bash"); err == nil {
+			unixShellPath = shellPath
+			return
 		}
+		if shellPath, err := exec.LookPath("sh"); err == nil {
+			unixShellPath = shellPath
+			return
+		}
+		unixShellPath = "sh"
 	})
 	return unixShellPath
 }

--- a/internal/tool/shell_command_unix.go
+++ b/internal/tool/shell_command_unix.go
@@ -13,7 +13,7 @@ var (
 	unixShellPathOnce sync.Once
 )
 
-func detectedUnixShellPath() string {
+func getUnixShellPath() string {
 	unixShellPathOnce.Do(func() {
 		unixShellPath = "bash"
 		if _, err := exec.LookPath(unixShellPath); err != nil {
@@ -24,5 +24,5 @@ func detectedUnixShellPath() string {
 }
 
 func newShellCommand(ctx context.Context, command string) *exec.Cmd {
-	return exec.CommandContext(ctx, detectedUnixShellPath(), "-c", command)
+	return exec.CommandContext(ctx, getUnixShellPath(), "-c", command)
 }

--- a/internal/tool/shell_command_windows.go
+++ b/internal/tool/shell_command_windows.go
@@ -4,9 +4,48 @@ package tool
 
 import (
 	"context"
+	"encoding/base64"
 	"os/exec"
+	"sync"
+	"unicode/utf16"
 )
 
+var (
+	winShellPath     string
+	winShellPathOnce sync.Once
+)
+
+func getWindowsShellPath() string {
+	winShellPathOnce.Do(func() {
+		if p, err := exec.LookPath("pwsh.exe"); err == nil {
+			winShellPath = p
+			return
+		}
+		if p, err := exec.LookPath("powershell.exe"); err == nil {
+			winShellPath = p
+			return
+		}
+		winShellPath = "powershell.exe"
+	})
+	return winShellPath
+}
+
+func encodePSCommand(command string) string {
+	u16 := utf16.Encode([]rune(command))
+	b := make([]byte, len(u16)*2)
+	for i, r := range u16 {
+		b[i*2] = byte(r)
+		b[i*2+1] = byte(r >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
 func newShellCommand(ctx context.Context, command string) *exec.Cmd {
-	return exec.CommandContext(ctx, "cmd.exe", "/C", command)
+	shell := getWindowsShellPath()
+	encoded := encodePSCommand(command)
+	return exec.CommandContext(
+		ctx, shell,
+		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-EncodedCommand", encoded,
+	)
 }

--- a/internal/tool/shell_command_windows.go
+++ b/internal/tool/shell_command_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tool
+
+import (
+	"context"
+	"os/exec"
+)
+
+func newShellCommand(ctx context.Context, command string) *exec.Cmd {
+	return exec.CommandContext(ctx, "cmd.exe", "/C", command)
+}

--- a/internal/tool/targetEdit_test.go
+++ b/internal/tool/targetEdit_test.go
@@ -21,6 +21,8 @@ func TestTargetEditTool(t *testing.T) {
 	file1 := "test.txt"
 	content := "line 1\nline 2\nline 3\n"
 	filePath := filepath.Join(tmpDir, file1)
+		// Use forward slashes so the path is valid JSON on all platforms (including Windows).
+		filePath = filepath.ToSlash(filePath)
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tui/interactions.go
+++ b/internal/tui/interactions.go
@@ -7,6 +7,7 @@ import (
 	"late/internal/client"
 	"late/internal/common"
 	"late/internal/tool"
+	"runtime"
 )
 
 // TUIInputProvider implements common.InputProvider by sending messages to the TUI.
@@ -61,7 +62,11 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 
 			// Check for unsupervised execution flag in context
 			if skip, ok := ctx.Value(common.SkipConfirmationKey).(bool); ok && skip {
-				return next(ctx, tc)
+				// On Windows, never bypass shell command confirmation.
+				if !(runtime.GOOS == "windows" && tc.Function.Name == "bash") {
+					approvedCtx := context.WithValue(ctx, common.ToolApprovalKey, true)
+					return next(approvedCtx, tc)
+				}
 			}
 
 			// Check if the tool requires confirmation
@@ -103,7 +108,8 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 				if !confirmed {
 					return "Tool execution cancelled by user", nil
 				}
-				return next(ctx, tc)
+				approvedCtx := context.WithValue(ctx, common.ToolApprovalKey, true)
+				return next(approvedCtx, tc)
 			case err := <-errCh:
 				return "", err
 			case <-ctx.Done():

--- a/internal/tui/interactions.go
+++ b/internal/tui/interactions.go
@@ -72,9 +72,9 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 						return next(ctx, tc)
 					}
 
-					// For BashTool, check if the command is blocked (e.g., cd commands)
+					// For ShellTool, check if the command is blocked (e.g., cd commands)
 					// Blocked commands should be rejected immediately without asking for confirmation
-					if bashTool, ok := t.(*tool.BashTool); ok {
+					if bashTool, ok := t.(*tool.ShellTool); ok {
 						var params struct {
 							Command string `json:"command"`
 						}

--- a/internal/tui/interactions_test.go
+++ b/internal/tui/interactions_test.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"late/internal/client"
 	"late/internal/common"
 	"late/internal/tool"
+	"runtime"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,11 +14,15 @@ import (
 
 type mockMessenger struct {
 	confirmCalled bool
+	autoConfirm   *bool
 }
 
 func (m *mockMessenger) Send(msg tea.Msg) {
-	if _, ok := msg.(ConfirmRequestMsg); ok {
+	if req, ok := msg.(ConfirmRequestMsg); ok {
 		m.confirmCalled = true
+		if m.autoConfirm != nil {
+			req.ResultCh <- *m.autoConfirm
+		}
 	}
 }
 
@@ -28,8 +34,13 @@ func TestTUIConfirmMiddleware_SkipConfirmation(t *testing.T) {
 
 	middleware := TUIConfirmMiddleware(messenger, reg)
 
+	var approvedSeen bool
+
 	// Next runner just returns success
 	next := func(ctx context.Context, tc client.ToolCall) (string, error) {
+		if approved, ok := ctx.Value(common.ToolApprovalKey).(bool); ok && approved {
+			approvedSeen = true
+		}
 		return "success", nil
 	}
 
@@ -45,7 +56,22 @@ func TestTUIConfirmMiddleware_SkipConfirmation(t *testing.T) {
 
 	t.Run("Unsupervised execution skips confirmation", func(t *testing.T) {
 		messenger.confirmCalled = false
+		approvedSeen = false
 		ctx := context.WithValue(context.Background(), common.SkipConfirmationKey, true)
+
+		if runtime.GOOS == "windows" {
+			// Windows policy: shell commands must still go through confirmation.
+			ctx, cancel := context.WithCancel(ctx)
+			cancel()
+			_, _ = runner(ctx, tc)
+			if !messenger.confirmCalled {
+				t.Errorf("Expected confirmation to be requested on Windows")
+			}
+			if approvedSeen {
+				t.Errorf("Did not expect approval marker when confirmation was not granted")
+			}
+			return
+		}
 
 		result, err := runner(ctx, tc)
 		if err != nil {
@@ -56,6 +82,9 @@ func TestTUIConfirmMiddleware_SkipConfirmation(t *testing.T) {
 		}
 		if messenger.confirmCalled {
 			t.Errorf("Expected confirmation to be skipped, but it was requested")
+		}
+		if !approvedSeen {
+			t.Errorf("Expected middleware to mark tool execution as approved in context")
 		}
 	})
 
@@ -71,4 +100,42 @@ func TestTUIConfirmMiddleware_SkipConfirmation(t *testing.T) {
 			t.Errorf("Expected confirmation to be requested")
 		}
 	})
+}
+
+func TestTUIConfirmMiddleware_ConfirmedExecutionMarksApproval(t *testing.T) {
+	autoConfirm := true
+	messenger := &mockMessenger{autoConfirm: &autoConfirm}
+	reg := common.NewToolRegistry()
+	bashTool := &tool.ShellTool{}
+	reg.Register(bashTool)
+
+	middleware := TUIConfirmMiddleware(messenger, reg)
+
+	next := func(ctx context.Context, tc client.ToolCall) (string, error) {
+		approved, ok := ctx.Value(common.ToolApprovalKey).(bool)
+		if !ok || !approved {
+			return "", fmt.Errorf("missing approval marker")
+		}
+		return "success", nil
+	}
+
+	runner := middleware(next)
+
+	tc := client.ToolCall{
+		Function: client.FunctionCall{
+			Name:      "bash",
+			Arguments: `{"command": "wget https://example.com"}`,
+		},
+	}
+
+	result, err := runner(context.Background(), tc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result != "success" {
+		t.Fatalf("Expected result 'success', got %q", result)
+	}
+	if !messenger.confirmCalled {
+		t.Fatalf("Expected confirmation to be requested")
+	}
 }

--- a/internal/tui/interactions_test.go
+++ b/internal/tui/interactions_test.go
@@ -23,7 +23,7 @@ func (m *mockMessenger) Send(msg tea.Msg) {
 func TestTUIConfirmMiddleware_SkipConfirmation(t *testing.T) {
 	messenger := &mockMessenger{}
 	reg := common.NewToolRegistry()
-	bashTool := &tool.BashTool{}
+	bashTool := &tool.ShellTool{}
 	reg.Register(bashTool)
 
 	middleware := TUIConfirmMiddleware(messenger, reg)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -248,7 +249,11 @@ func (m *Model) updateViewport() {
 	// Render Interactions
 	if s.State == StateConfirmTool && s.PendingConfirm != nil {
 		tc := s.PendingConfirm.ToolCall
-		prompt := fmt.Sprintf("The agent wants to execute **%s**.\n\n```json\n%s\n```\n\n> Press **[ y ]** to Approve  |  **[ n ]** to Deny", tc.Function.Name, tc.Function.Arguments)
+		displayName := tc.Function.Name
+		if runtime.GOOS == "windows" && displayName == "bash" {
+			displayName = "PowerShell"
+		}
+		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[ y ]** to Approve  |  **[ n ]** to Deny", displayName, tc.Function.Arguments)
 		md, _ := m.Renderer.Render(prompt)
 		blocks = append(blocks, aiMsgStyle.Width(msgWidth).Border(lipgloss.DoubleBorder()).BorderForeground(lipgloss.Color("#FFD700")).Render(md))
 	}


### PR DESCRIPTION
## Summary
Adds full Windows support to `late`, enabling cross-platform compilation and
execution on both Windows and Linux/macOS.

## Changes

### Platform-aware shell execution
- Added `shell_command_windows.go` — uses `cmd.exe /C` on Windows
- Added `shell_command_unix.go` — resolves `bash`/`sh` at runtime with lazy
  caching, falling back gracefully if `bash` is not found
- Build tags (`//go:build windows` / `//go:build !windows`) ensure the correct
  implementation is compiled per platform

### Cross-platform path utilities
- Added `path_utils.go` with `LateConfigDir()` and `LateSessionDir()`:
  - Windows: stores config and sessions under `%AppData%\late` via `UserConfigDir()`
  - Linux/macOS: sessions stored under `~/.local/share/late/sessions` (XDG convention)
- Added `path_utils_test.go` with platform-conditional assertions

### General fixes & polish
- Updated `config.go`, `executor.go`, `mcp/config.go`, `session/models.go`,
  and TUI interactions to use the new path helpers
- Renamed shell helper variables for clarity; aligned docs examples
- Added tests for the shell command abstraction layer

## Testing
- All existing tests pass on both Windows and Linux
- New tests cover: path resolution per OS, shell command construction,
  Unix shell fallback behavior
  
  
<img width="1110" height="919" alt="image" src="https://github.com/user-attachments/assets/8e95c746-267d-42d3-928c-e1bb55fc72be" />

  
  