### PR TITLE
fix: restore previous tui.View() behavior to get TUI working in WSL again

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -286,6 +286,7 @@ func (m *Model) renderMarkdownBlock(content string, innerWidth int) string {
 	fullWidth := m.Viewport.Width - AIMsgOverhead
 	bgPrefix := "\x1b[48;2;25;25;25;38;2;85;85;85m"
 
+
 	for i, line := range lines {
 		pad := fullWidth - lipgloss.Width(line)
 		if pad < 0 {
@@ -334,6 +335,7 @@ func (m *Model) renderPlainBlock(content string) string {
 	// we can use simple rune counting for wrapping — essentially free.
 	wrapped := wordWrap(content, fullWidth)
 	lines := strings.Split(wrapped, "\n")
+
 
 	for i, line := range lines {
 		pad := fullWidth - len(line)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -14,24 +14,14 @@ func (m Model) View() string {
 		return ""
 	}
 
-	content := lipgloss.JoinVertical(
-		lipgloss.Left,
-		m.Viewport.View(),
-		m.inputView(),
-		m.statusBarView(),
+	return appStyle.Width(m.Width).Height(m.Height).Render(
+		lipgloss.JoinVertical(
+			lipgloss.Left,
+			m.Viewport.View(),
+			m.inputView(),
+			m.statusBarView(),
+		),
 	)
-
-	// Fill each line's remaining width with our dark background using the
-	// terminal's Erase-in-Line sequence. This only processes ~40-50 lines
-	// (terminal height) so it's negligible — unlike the old appStyle.Render
-	// which parsed ANSI codes in the entire viewport content.
-	bg := "\x1b[48;2;25;25;25m"
-	eolFill := "\x1b[48;2;25;25;25m\x1b[K"
-	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		lines[i] = bg + line + eolFill
-	}
-	return strings.Join(lines, "\n")
 }
 
 func (m *Model) inputView() string {
@@ -296,7 +286,6 @@ func (m *Model) renderMarkdownBlock(content string, innerWidth int) string {
 	fullWidth := m.Viewport.Width - AIMsgOverhead
 	bgPrefix := "\x1b[48;2;25;25;25;38;2;85;85;85m"
 
-
 	for i, line := range lines {
 		pad := fullWidth - lipgloss.Width(line)
 		if pad < 0 {
@@ -345,7 +334,6 @@ func (m *Model) renderPlainBlock(content string) string {
 	// we can use simple rune counting for wrapping — essentially free.
 	wrapped := wordWrap(content, fullWidth)
 	lines := strings.Split(wrapped, "\n")
-
 
 	for i, line := range lines {
 		pad := fullWidth - len(line)


### PR DESCRIPTION
### Description of Changes
I fed Qwen3.6 a diff of v1.0.4 -> v1.0.5 to figure out why the TUI stopped working on WSL. It recommended reverting the change to tui.View().  I am attaching its analysis of why this change is correct and performant.  I am not a TUI expert yet but I can confirm the fix works to get it working in WSL terminals again.
[performance_analysis.md](https://github.com/user-attachments/files/26975853/performance_analysis.md)
[root_cause.md](https://github.com/user-attachments/files/26975854/root_cause.md)


### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [x] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](./CLA.md) in this repository.** *(To check the box, put an `x` between the brackets like this: `[x]`)*