### PR TITLE
feat(config): support OpenAI settings via app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ export OPENAI_BASE_URL="http://localhost:8080"
 # export OPENAI_MODEL="qwen3.5-35b-a3b"
 ```
 
+Late can also read those values from `config.json` in the Late config directory. Environment variables take precedence over `config.json` when both are set. On Windows that directory resolves to `%AppData%/late`.
+
+```json
+{
+	"openai_base_url": "http://localhost:8080",
+	"openai_api_key": "your-key",
+	"openai_model": "qwen3.5-35b-a3b"
+}
+```
+
 **3. Execute**
 
 ```bash

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -149,16 +149,6 @@ func main() {
 		history = []client.ChatMessage{}
 	}
 
-	// Initialize Core Components
-	baseURL := os.Getenv("OPENAI_BASE_URL")
-	if baseURL == "" {
-		baseURL = "http://localhost:8080"
-	}
-	apiKey := os.Getenv("OPENAI_API_KEY")
-	modelName := os.Getenv("OPENAI_MODEL")
-	cfg := client.Config{BaseURL: baseURL, APIKey: apiKey, Model: modelName}
-	c := client.NewClient(cfg)
-
 	// Initialize MCP client
 	mcpClient := mcp.NewClient()
 	defer mcpClient.Close()
@@ -188,6 +178,10 @@ func main() {
 			enabledTools[toolName] = enabled
 		}
 	}
+
+	// Initialize Core Components
+	resolvedClientConfig := client.ResolveConfig(appConfig)
+	c := client.NewClient(resolvedClientConfig)
 
 	// Flag overrides
 	if !*enableBashReq {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,6 +16,18 @@ export OPENAI_API_KEY="your-key"
 export OPENAI_MODEL="your-model"
 ```
 
+You can also store the same values in Late's app config file. Environment variables override `config.json` when both are present.
+
+Windows config path: `%AppData%/late/config.json`
+
+```json
+{
+  "openai_base_url": "http://localhost:8080",
+  "openai_api_key": "your-key",
+  "openai_model": "your-model"
+}
+```
+
 **2. Launch Late from your project directory:**
 
 ```bash

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,10 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	appconfig "late/internal/config"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
+
+const DefaultBaseURL = "http://localhost:8080"
 
 type Config struct {
 	BaseURL string
@@ -21,6 +25,49 @@ type Config struct {
 type Client struct {
 	cfg        Config
 	httpClient *http.Client
+}
+
+type EnvLookup func(string) (string, bool)
+
+func ResolveConfig(cfg *appconfig.Config) Config {
+	return ResolveConfigWithEnv(cfg, os.LookupEnv)
+}
+
+func ResolveConfigWithEnv(cfg *appconfig.Config, lookup EnvLookup) Config {
+	resolved := Config{BaseURL: DefaultBaseURL}
+
+	if cfg != nil {
+		if cfg.OpenAIBaseURL != "" {
+			resolved.BaseURL = cfg.OpenAIBaseURL
+		}
+		resolved.APIKey = cfg.OpenAIAPIKey
+		resolved.Model = cfg.OpenAIModel
+	}
+
+	if value, ok := nonEmptyEnv(lookup, "OPENAI_BASE_URL"); ok {
+		resolved.BaseURL = value
+	}
+	if value, ok := nonEmptyEnv(lookup, "OPENAI_API_KEY"); ok {
+		resolved.APIKey = value
+	}
+	if value, ok := nonEmptyEnv(lookup, "OPENAI_MODEL"); ok {
+		resolved.Model = value
+	}
+
+	return resolved
+}
+
+func nonEmptyEnv(lookup EnvLookup, key string) (string, bool) {
+	if lookup == nil {
+		return "", false
+	}
+
+	value, ok := lookup(key)
+	if !ok || value == "" {
+		return "", false
+	}
+
+	return value, true
 }
 
 func NewClient(cfg Config) *Client {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	appconfig "late/internal/config"
+	"testing"
+)
+
+func TestResolveConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *appconfig.Config
+		env     map[string]string
+		present map[string]bool
+		want    Config
+	}{
+		{
+			name: "env only",
+			env: map[string]string{
+				"OPENAI_BASE_URL": "https://env.example",
+				"OPENAI_API_KEY":  "env-key",
+				"OPENAI_MODEL":    "env-model",
+			},
+			present: map[string]bool{
+				"OPENAI_BASE_URL": true,
+				"OPENAI_API_KEY":  true,
+				"OPENAI_MODEL":    true,
+			},
+			want: Config{BaseURL: "https://env.example", APIKey: "env-key", Model: "env-model"},
+		},
+		{
+			name: "config only",
+			cfg: &appconfig.Config{
+				OpenAIBaseURL: "https://config.example",
+				OpenAIAPIKey:  "config-key",
+				OpenAIModel:   "config-model",
+			},
+			want: Config{BaseURL: "https://config.example", APIKey: "config-key", Model: "config-model"},
+		},
+		{
+			name: "env wins over config",
+			cfg: &appconfig.Config{
+				OpenAIBaseURL: "https://config.example",
+				OpenAIAPIKey:  "config-key",
+				OpenAIModel:   "config-model",
+			},
+			env: map[string]string{
+				"OPENAI_BASE_URL": "https://env.example",
+				"OPENAI_API_KEY":  "env-key",
+				"OPENAI_MODEL":    "env-model",
+			},
+			present: map[string]bool{
+				"OPENAI_BASE_URL": true,
+				"OPENAI_API_KEY":  true,
+				"OPENAI_MODEL":    true,
+			},
+			want: Config{BaseURL: "https://env.example", APIKey: "env-key", Model: "env-model"},
+		},
+		{
+			name: "none set uses default URL",
+			want: Config{BaseURL: DefaultBaseURL},
+		},
+		{
+			name: "empty env falls back to config",
+			cfg: &appconfig.Config{
+				OpenAIBaseURL: "https://config.example",
+				OpenAIAPIKey:  "config-key",
+				OpenAIModel:   "config-model",
+			},
+			env: map[string]string{
+				"OPENAI_BASE_URL": "",
+				"OPENAI_API_KEY":  "",
+				"OPENAI_MODEL":    "",
+			},
+			present: map[string]bool{
+				"OPENAI_BASE_URL": true,
+				"OPENAI_API_KEY":  true,
+				"OPENAI_MODEL":    true,
+			},
+			want: Config{BaseURL: "https://config.example", APIKey: "config-key", Model: "config-model"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveConfigWithEnv(tt.cfg, func(key string) (string, bool) {
+				value, ok := tt.env[key]
+				if tt.present != nil {
+					ok = tt.present[key]
+				}
+				return value, ok
+			})
+
+			if got.BaseURL != tt.want.BaseURL {
+				t.Fatalf("BaseURL = %q, want %q", got.BaseURL, tt.want.BaseURL)
+			}
+			if got.APIKey != tt.want.APIKey {
+				t.Fatalf("APIKey = %q, want %q", got.APIKey, tt.want.APIKey)
+			}
+			if got.Model != tt.want.Model {
+				t.Fatalf("Model = %q, want %q", got.Model, tt.want.Model)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,29 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
 // Config represents the application configuration.
 type Config struct {
-	EnabledTools map[string]bool `json:"enabled_tools"`
+	EnabledTools  map[string]bool `json:"enabled_tools"`
+	OpenAIBaseURL string          `json:"openai_base_url,omitempty"`
+	OpenAIAPIKey  string          `json:"openai_api_key,omitempty"`
+	OpenAIModel   string          `json:"openai_model,omitempty"`
+}
+
+func defaultConfig() Config {
+	return Config{
+		EnabledTools: map[string]bool{
+			"read_file":      true,
+			"write_file":     true,
+			"target_edit":    true,
+			"spawn_subagent": true,
+			"bash":           true,
+		},
+	}
 }
 
 func LoadConfig() (*Config, error) {
@@ -24,34 +40,31 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Pre-populate with a default config that enables everything
-			defaultConfig := Config{
-				EnabledTools: map[string]bool{
-					"read_file":      true,
-					"write_file":     true,
-					"target_edit":    true,
-					"spawn_subagent": true,
-					"bash":           true,
-				},
-			}
-			defaultData, _ := json.MarshalIndent(defaultConfig, "", "  ")
+			fallback := defaultConfig()
+			defaultData, _ := json.MarshalIndent(fallback, "", "  ")
 
 			// Ensure directory exists
 			if err := os.MkdirAll(lateConfigDir, 0755); err != nil {
-				return &Config{}, nil // Fallback to empty config if we can't create dir
+				return &fallback, fmt.Errorf("failed to create config directory: %w", err)
 			}
 
 			if err := os.WriteFile(configPath, defaultData, 0644); err != nil {
-				return &Config{}, nil // Fallback to empty config if we can't write file
+				return &fallback, fmt.Errorf("failed to write default config: %w", err)
 			}
 
-			return &defaultConfig, nil
+			return &fallback, nil
 		}
 		return nil, err
 	}
 
 	var cfg Config
 	if err := json.Unmarshal(content, &cfg); err != nil {
-		return nil, err
+		fallback := defaultConfig()
+		return &fallback, err
+	}
+
+	if cfg.EnabledTools == nil {
+		cfg.EnabledTools = defaultConfig().EnabledTools
 	}
 
 	return &cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLoadConfig_MissingFileCreatesDefault(t *testing.T) {
+	configRoot := t.TempDir()
+	setUserConfigEnv(t, configRoot)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadConfig() returned nil config")
+	}
+	if !cfg.EnabledTools["read_file"] || !cfg.EnabledTools["bash"] {
+		t.Fatalf("LoadConfig() missing default enabled tools: %#v", cfg.EnabledTools)
+	}
+
+	configPath := filepath.Join(configRoot, "late", "config.json")
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("expected config file to be created at %s: %v", configPath, err)
+	}
+	if cfg.OpenAIBaseURL != "" || cfg.OpenAIAPIKey != "" || cfg.OpenAIModel != "" {
+		t.Fatal("expected default OpenAI fields to be empty")
+	}
+}
+
+func TestLoadConfig_ParsesLegacyConfig(t *testing.T) {
+	configRoot := t.TempDir()
+	setUserConfigEnv(t, configRoot)
+	configPath := filepath.Join(configRoot, "late", "config.json")
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"enabled_tools":{"bash":false,"read_file":true}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.EnabledTools["bash"] {
+		t.Fatal("expected bash to be disabled from legacy config")
+	}
+	if !cfg.EnabledTools["read_file"] {
+		t.Fatal("expected read_file to remain enabled from legacy config")
+	}
+	if cfg.OpenAIBaseURL != "" || cfg.OpenAIAPIKey != "" || cfg.OpenAIModel != "" {
+		t.Fatal("expected legacy config to leave OpenAI fields empty")
+	}
+}
+
+func TestLoadConfig_ParsesOpenAIFields(t *testing.T) {
+	configRoot := t.TempDir()
+	setUserConfigEnv(t, configRoot)
+	configPath := filepath.Join(configRoot, "late", "config.json")
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{
+		"enabled_tools": {"bash": true},
+		"openai_base_url": "https://example.test/v1",
+		"openai_api_key": "secret",
+		"openai_model": "gpt-test"
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.OpenAIBaseURL != "https://example.test/v1" {
+		t.Fatalf("OpenAIBaseURL = %q", cfg.OpenAIBaseURL)
+	}
+	if cfg.OpenAIAPIKey != "secret" {
+		t.Fatalf("OpenAIAPIKey = %q", cfg.OpenAIAPIKey)
+	}
+	if cfg.OpenAIModel != "gpt-test" {
+		t.Fatalf("OpenAIModel = %q", cfg.OpenAIModel)
+	}
+}
+
+func TestLoadConfig_MalformedFileFallsBackWithError(t *testing.T) {
+	configRoot := t.TempDir()
+	setUserConfigEnv(t, configRoot)
+	configPath := filepath.Join(configRoot, "late", "config.json")
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"enabled_tools":`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected parse error for malformed config")
+	}
+	if cfg == nil {
+		t.Fatal("expected fallback config despite parse error")
+	}
+	if !cfg.EnabledTools["write_file"] || !cfg.EnabledTools["target_edit"] {
+		t.Fatalf("expected fallback default tools, got %#v", cfg.EnabledTools)
+	}
+}
+
+func TestLoadConfig_DefaultCreateFailureFallsBackWithError(t *testing.T) {
+	configRoot := t.TempDir()
+	blockingPath := filepath.Join(configRoot, "not-a-dir")
+	if err := os.WriteFile(blockingPath, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setUserConfigEnv(t, blockingPath)
+
+	cfg, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error when config directory cannot be created")
+	}
+	if cfg == nil {
+		t.Fatal("expected fallback config despite creation failure")
+	}
+	if !cfg.EnabledTools["read_file"] || !cfg.EnabledTools["bash"] {
+		t.Fatalf("expected fallback default tools, got %#v", cfg.EnabledTools)
+	}
+}
+
+func setUserConfigEnv(t *testing.T, configRoot string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", configRoot)
+	t.Setenv("APPDATA", configRoot)
+	if runtime.GOOS != "windows" {
+		t.Setenv("HOME", configRoot)
+	}
+}


### PR DESCRIPTION
- add openai_base_url, openai_api_key, and openai_model to app config

- centralize client config resolution with env > config > defaults precedence

- wire cmd/late startup through client.ResolveConfig

- return fallback defaults with surfaced errors on config create/parse failures

- add regression tests for config loading and resolver precedence

- document config keys, precedence behavior, and Windows config path

### Description of Changes



### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [x] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](./CLA.md) in this repository.** *(To check the box, put an `x` between the brackets like this: `[x]`)*