### PR TITLE
Constrain shell auto-approval to new paths within cwd

### DIFF
--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -238,13 +238,19 @@ func extractTargetPath(command string) string {
 	if len(fields) != 2 {
 		return ""
 	}
-	if strings.HasPrefix(fields[1], "-") {
+	target := fields[1]
+	if strings.HasPrefix(target, "-") {
+		return ""
+	}
+	// Reject shell-expanded targets so auto-approval remains conservative
+	// when execution runs through bash -c.
+	if strings.HasPrefix(target, "~") || strings.Contains(target, "$") || strings.ContainsAny(target, "*?[") {
 		return ""
 	}
 
 	switch strings.ToLower(fields[0]) {
 	case "mkdir", "touch", "new-item":
-		return fields[1]
+		return target
 	default:
 		return ""
 	}

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -230,6 +230,26 @@ func containsShellMetacharacters(command string) bool {
 	return false
 }
 
+// extractTargetPath returns the target path argument for simple creation
+// commands. It intentionally refuses flags, chaining, and other ambiguous
+// forms so they continue through the normal confirmation path.
+func extractTargetPath(command string) string {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) != 2 {
+		return ""
+	}
+	if strings.HasPrefix(fields[1], "-") {
+		return ""
+	}
+
+	switch strings.ToLower(fields[0]) {
+	case "mkdir", "touch", "new-item":
+		return fields[1]
+	default:
+		return ""
+	}
+}
+
 // Maximum number of output lines to prevent memory exhaustion
 const maxBashOutputLines = 1024
 
@@ -487,6 +507,7 @@ func (t ShellTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 func (t ShellTool) RequiresConfirmation(args json.RawMessage) bool {
 	var params struct {
 		Command string `json:"command"`
+		Cwd     string `json:"cwd"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return true // Default to requiring confirmation if we can't parse
@@ -503,6 +524,10 @@ func (t ShellTool) RequiresConfirmation(args json.RawMessage) bool {
 	// syntax, we just punt to the human.
 	if containsShellMetacharacters(params.Command) {
 		return true
+	}
+
+	if target := extractTargetPath(params.Command); target != "" && isNewPath(target, params.Cwd) {
+		return false
 	}
 
 	// Get all base commands from potentially compound commands

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -187,6 +187,186 @@ var whitelistedCommands = map[string]bool{
 	"file":   true,
 }
 
+// Windows PowerShell commands that are considered read-only/safe for
+// auto-approval when no risky syntax is present.
+var whitelistedWindowsCommands = map[string]bool{
+	"cat":            true,
+	"date":           true,
+	"dir":            true,
+	"echo":           true,
+	"gc":             true,
+	"gci":            true,
+	"get-childitem":  true,
+	"get-content":    true,
+	"get-date":       true,
+	"get-location":   true,
+	"ls":             true,
+	"measure-object": true,
+	"pwd":            true,
+	"select-string":  true,
+	"sls":            true,
+	"type":           true,
+	"whoami":         true,
+	"write-output":   true,
+}
+
+// tokenizePowerShellCommand splits a command into tokens while honoring
+// single/double quotes and PowerShell backtick escaping.
+func tokenizePowerShellCommand(command string) []string {
+	tokens := make([]string, 0)
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	flush := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+
+	for i := 0; i < len(command); i++ {
+		ch := command[i]
+
+		if escaped {
+			current.WriteByte(ch)
+			escaped = false
+			continue
+		}
+
+		if !inSingle && ch == '`' {
+			escaped = true
+			continue
+		}
+
+		if ch == '\'' && !inDouble {
+			inSingle = !inSingle
+			continue
+		}
+		if ch == '"' && !inSingle {
+			inDouble = !inDouble
+			continue
+		}
+
+		if !inSingle && !inDouble {
+			if ch == ';' || ch == '|' {
+				flush()
+				tokens = append(tokens, string(ch))
+				continue
+			}
+			if ch == '&' {
+				flush()
+				if i+1 < len(command) && command[i+1] == '&' {
+					tokens = append(tokens, "&&")
+					i++
+				} else {
+					tokens = append(tokens, "&")
+				}
+				continue
+			}
+			if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
+				flush()
+				continue
+			}
+		}
+
+		current.WriteByte(ch)
+	}
+
+	flush()
+	return tokens
+}
+
+func getPowerShellBaseCommands(command string) []string {
+	tokens := tokenizePowerShellCommand(command)
+	commands := make([]string, 0)
+	expectCommand := true
+
+	for _, token := range tokens {
+		switch token {
+		case ";", "|", "||", "&&", "&":
+			expectCommand = true
+			continue
+		}
+		if expectCommand {
+			commands = append(commands, strings.ToLower(token))
+			expectCommand = false
+		}
+	}
+
+	return commands
+}
+
+func containsPowerShellRiskySyntax(command string) bool {
+	lower := strings.ToLower(command)
+	if strings.ContainsAny(command, "\n\r\x00") {
+		return true
+	}
+	if strings.ContainsAny(command, "><") {
+		return true
+	}
+	if strings.Contains(lower, "$(") {
+		return true
+	}
+
+	for _, keyword := range []string{
+		" invoke-expression",
+		" iex ",
+		" start-process",
+		" invoke-command",
+		" new-object",
+		" remove-item",
+		" rename-item",
+		" move-item",
+		" copy-item",
+		" set-content",
+		" add-content",
+		" out-file",
+		" clear-content",
+		" set-itemproperty",
+		" -encodedcommand",
+	} {
+		if strings.Contains(" "+lower, keyword) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func extractPowerShellTargetPath(command string) string {
+	tokens := tokenizePowerShellCommand(strings.TrimSpace(command))
+	if len(tokens) < 2 {
+		return ""
+	}
+
+	cmd := strings.ToLower(tokens[0])
+	target := ""
+
+	switch cmd {
+	case "mkdir", "md":
+		target = tokens[1]
+	case "new-item", "ni":
+		if len(tokens) == 2 {
+			target = tokens[1]
+		} else if len(tokens) >= 3 && strings.EqualFold(tokens[1], "-Path") {
+			target = tokens[2]
+		}
+	default:
+		return ""
+	}
+
+	if target == "" || strings.HasPrefix(target, "-") {
+		return ""
+	}
+	if strings.HasPrefix(target, "~") || strings.Contains(target, "$") || strings.ContainsAny(target, "*?[") {
+		return ""
+	}
+
+	return target
+}
+
 // containsShellMetacharacters returns true if the command string contains
 // any shell syntax that could embed or disguise a sub-command.
 // When this returns true, RequiresConfirmation should always return true
@@ -519,9 +699,27 @@ func (t ShellTool) RequiresConfirmation(args json.RawMessage) bool {
 		return true // Default to requiring confirmation if we can't parse
 	}
 
-	// Conservative Windows policy: always require confirmation.
 	if runtime.GOOS == "windows" {
-		return true
+		// Denylist first: if command shape is risky or can hide execution intent,
+		// always require confirmation.
+		if containsPowerShellRiskySyntax(params.Command) {
+			return true
+		}
+
+		// Permit creation only for simple, explicit new paths inside allowed roots.
+		if target := extractPowerShellTargetPath(params.Command); target != "" && isNewPath(target, params.Cwd) {
+			return false
+		}
+
+		// Parser-backed base command extraction allows safer classification than
+		// naive whitespace splitting.
+		baseCommands := getPowerShellBaseCommands(params.Command)
+		for _, cmd := range baseCommands {
+			if !whitelistedWindowsCommands[cmd] {
+				return true
+			}
+		}
+		return false
 	}
 
 	// If the command contains any shell metacharacters that could embed

--- a/internal/tool/implementations_bash_test.go
+++ b/internal/tool/implementations_bash_test.go
@@ -621,6 +621,11 @@ func TestExtractTargetPath(t *testing.T) {
 	}{
 		{name: "mkdir simple", command: "mkdir src/components", want: "src/components"},
 		{name: "touch simple", command: "touch src/index.go", want: "src/index.go"},
+		{name: "reject tilde expansion", command: "touch ~/out.txt", want: ""},
+		{name: "reject env expansion", command: "touch $HOME/out.txt", want: ""},
+		{name: "reject glob star", command: "touch *.txt", want: ""},
+		{name: "reject glob question", command: "touch file?.txt", want: ""},
+		{name: "reject glob bracket", command: "touch [ab].txt", want: ""},
 		{name: "mkdir flagged", command: "mkdir -p src/a/b", want: ""},
 		{name: "compound", command: "mkdir src && cd src", want: ""},
 		{name: "whitespace only", command: "   ", want: ""},
@@ -670,6 +675,16 @@ func TestShellToolRequiresConfirmation_NewPathCreationWithinProject(t *testing.T
 		{
 			name: "outside cwd prompts",
 			args: `{"command":"touch ../outside.txt","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: true,
+		},
+		{
+			name: "tilde expansion prompts",
+			args: `{"command":"touch ~/x.txt","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: true,
+		},
+		{
+			name: "env expansion prompts",
+			args: `{"command":"touch $HOME/x.txt","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
 			want: true,
 		},
 		{
@@ -737,6 +752,34 @@ func TestShellToolRequiresConfirmation_ReducesPromptedCallsForScaffoldTask(t *te
 	}
 	if currentPrompts >= baselinePrompts {
 		t.Fatalf("expected fewer prompted calls after change, baseline=%d current=%d", baselinePrompts, currentPrompts)
+	}
+}
+
+func TestShellToolRequiresConfirmation_SymlinkEscapeFromCwdPrompts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows always requires confirmation")
+	}
+
+	projectDir, err := os.MkdirTemp(".", "shell-symlink-")
+	if err != nil {
+		t.Fatalf("mkdirtemp project: %v", err)
+	}
+	defer os.RemoveAll(projectDir)
+
+	outsideDir, err := os.MkdirTemp(".", "shell-outside-")
+	if err != nil {
+		t.Fatalf("mkdirtemp outside: %v", err)
+	}
+	defer os.RemoveAll(outsideDir)
+
+	if err := os.Symlink(filepath.ToSlash(outsideDir), filepath.Join(projectDir, "link")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	tool := ShellTool{}
+	args := json.RawMessage(`{"command":"touch link/newfile.txt","cwd":"` + filepath.ToSlash(projectDir) + `"}`)
+	if got := tool.RequiresConfirmation(args); !got {
+		t.Fatalf("expected RequiresConfirmation to prompt for symlink escape path")
 	}
 }
 

--- a/internal/tool/implementations_bash_test.go
+++ b/internal/tool/implementations_bash_test.go
@@ -1,7 +1,11 @@
 package tool
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -607,4 +611,153 @@ func TestContainsShellMetacharacters(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractTargetPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "mkdir simple", command: "mkdir src/components", want: "src/components"},
+		{name: "touch simple", command: "touch src/index.go", want: "src/index.go"},
+		{name: "mkdir flagged", command: "mkdir -p src/a/b", want: ""},
+		{name: "compound", command: "mkdir src && cd src", want: ""},
+		{name: "whitespace only", command: "   ", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractTargetPath(tt.command); got != tt.want {
+				t.Fatalf("extractTargetPath(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellToolRequiresConfirmation_NewPathCreationWithinProject(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows always requires confirmation")
+	}
+
+	projectDir, err := os.MkdirTemp(".", "shell-create-")
+	if err != nil {
+		t.Fatalf("mkdirtemp: %v", err)
+	}
+	defer os.RemoveAll(projectDir)
+
+	tool := ShellTool{}
+	tests := []struct {
+		name string
+		args string
+		want bool
+	}{
+		{
+			name: "new mkdir inside cwd auto approves",
+			args: `{"command":"mkdir scaffold","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: false,
+		},
+		{
+			name: "new touch inside cwd auto approves",
+			args: `{"command":"touch scaffold.txt","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: false,
+		},
+		{
+			name: "existing path prompts",
+			args: `{"command":"mkdir existing","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: true,
+		},
+		{
+			name: "outside cwd prompts",
+			args: `{"command":"touch ../outside.txt","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: true,
+		},
+		{
+			name: "flagged mkdir prompts",
+			args: `{"command":"mkdir -p nested/path","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: true,
+		},
+		{
+			name: "compound command prompts",
+			args: `{"command":"mkdir scaffold && ls","cwd":"` + filepath.ToSlash(projectDir) + `"}`,
+			want: true,
+		},
+	}
+
+	if err := os.Mkdir(filepath.Join(projectDir, "existing"), 0755); err != nil {
+		t.Fatalf("prepare existing dir: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := json.RawMessage(tt.args)
+			got := tool.RequiresConfirmation(args)
+			if got != tt.want {
+				t.Fatalf("RequiresConfirmation(%s) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellToolRequiresConfirmation_ReducesPromptedCallsForScaffoldTask(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows always requires confirmation")
+	}
+
+	projectDir, err := os.MkdirTemp(".", "shell-task-")
+	if err != nil {
+		t.Fatalf("mkdirtemp: %v", err)
+	}
+	defer os.RemoveAll(projectDir)
+
+	tool := ShellTool{}
+	task := []json.RawMessage{
+		json.RawMessage(`{"command":"mkdir scaffold","cwd":"` + filepath.ToSlash(projectDir) + `"}`),
+		json.RawMessage(`{"command":"touch scaffold/main.go","cwd":"` + filepath.ToSlash(projectDir) + `"}`),
+		json.RawMessage(`{"command":"touch scaffold/README.md","cwd":"` + filepath.ToSlash(projectDir) + `"}`),
+		json.RawMessage(`{"command":"ls scaffold","cwd":"` + filepath.ToSlash(projectDir) + `"}`),
+	}
+
+	baselinePrompts := 0
+	currentPrompts := 0
+	for _, args := range task {
+		if oldShellRequiresConfirmation(args) {
+			baselinePrompts++
+		}
+		if tool.RequiresConfirmation(args) {
+			currentPrompts++
+		}
+	}
+
+	if baselinePrompts != 3 {
+		t.Fatalf("expected old behavior to prompt 3 times, got %d", baselinePrompts)
+	}
+	if currentPrompts != 0 {
+		t.Fatalf("expected new behavior to prompt 0 times for the same task, got %d", currentPrompts)
+	}
+	if currentPrompts >= baselinePrompts {
+		t.Fatalf("expected fewer prompted calls after change, baseline=%d current=%d", baselinePrompts, currentPrompts)
+	}
+}
+
+func oldShellRequiresConfirmation(args json.RawMessage) bool {
+	var params struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	if containsShellMetacharacters(params.Command) {
+		return true
+	}
+	baseCommands := getAllBaseCommands(params.Command)
+	for _, cmd := range baseCommands {
+		if !whitelistedCommands[cmd] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/tool/implementations_cmd_test.go
+++ b/internal/tool/implementations_cmd_test.go
@@ -5,6 +5,7 @@ package tool
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"late/internal/common"
 	"path/filepath"
 	"strings"
@@ -83,17 +84,93 @@ func TestPSShellCommand_EncodedCommandDecodesCorrectly(t *testing.T) {
 	}
 }
 
-func TestPSShellTool_WindowsAlwaysRequiresConfirmation(t *testing.T) {
+func TestPSShellTool_WindowsSelectiveRequiresConfirmation(t *testing.T) {
 	tool := ShellTool{}
-	cases := []json.RawMessage{
-		json.RawMessage(`{"command":"dir"}`),
-		json.RawMessage(`{"command":"Get-ChildItem"}`),
-		json.RawMessage(`{"command":"echo hello"}`),
+	tests := []struct {
+		name string
+		args json.RawMessage
+		want bool
+	}{
+		{name: "dir is safe", args: json.RawMessage(`{"command":"dir"}`), want: false},
+		{name: "Get-ChildItem is safe", args: json.RawMessage(`{"command":"Get-ChildItem"}`), want: false},
+		{name: "echo is safe", args: json.RawMessage(`{"command":"echo hello"}`), want: false},
+		{name: "risky remove-item", args: json.RawMessage(`{"command":"Remove-Item foo.txt"}`), want: true},
+		{name: "unknown command", args: json.RawMessage(`{"command":"git status"}`), want: true},
+		{name: "pipeline to unknown command", args: json.RawMessage(`{"command":"Get-ChildItem | ForEach-Object { $_ }"}`), want: true},
+		{name: "iex risky syntax", args: json.RawMessage(`{"command":"IEX 'Get-ChildItem'"}`), want: true},
 	}
-	for _, args := range cases {
-		if !tool.RequiresConfirmation(args) {
-			t.Fatalf("expected RequiresConfirmation=true on Windows for %s", string(args))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tool.RequiresConfirmation(tt.args); got != tt.want {
+				t.Fatalf("RequiresConfirmation(%s)=%v, want %v", string(tt.args), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPSShellTool_WindowsNewPathCarveout(t *testing.T) {
+	tool := ShellTool{}
+	tempDir := t.TempDir()
+	newPath := filepath.Join(tempDir, "new-folder")
+	existingPath := filepath.Join(tempDir, "existing-folder")
+	if err := os.Mkdir(existingPath, 0755); err != nil {
+		t.Fatalf("failed to create existing folder fixture: %v", err)
+	}
+	makeArgs := func(command, cwd string) json.RawMessage {
+		payload, err := json.Marshal(map[string]string{
+			"command": command,
+			"cwd":     cwd,
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal args: %v", err)
 		}
+		return json.RawMessage(payload)
+	}
+
+	tests := []struct {
+		name string
+		args json.RawMessage
+		want bool
+	}{
+		{
+			name: "new-item new path can auto-approve",
+				args: makeArgs(`New-Item -Path "`+newPath+`"`, tempDir),
+			want: false,
+		},
+		{
+			name: "new-item existing path requires confirmation",
+				args: makeArgs(`New-Item -Path "`+existingPath+`"`, tempDir),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tool.RequiresConfirmation(tt.args); got != tt.want {
+				t.Fatalf("RequiresConfirmation(%s)=%v, want %v", string(tt.args), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPowerShellParserBackedCommandExtraction(t *testing.T) {
+	got := getPowerShellBaseCommands(`Get-ChildItem 'C:\Program Files' | Select-String "go"; echo done`)
+	want := []string{"get-childitem", "select-string", "echo"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("getPowerShellBaseCommands mismatch: got %v want %v", got, want)
+	}
+
+	if !containsPowerShellRiskySyntax("IEX 'Get-ChildItem'") {
+		t.Fatal("expected IEX command to be treated as risky")
+	}
+
+	if containsPowerShellRiskySyntax("Get-ChildItem") {
+		t.Fatal("expected simple Get-ChildItem to be non-risky")
+	}
+
+	if got := extractPowerShellTargetPath(`New-Item -Path C:\tmp\newfile.txt`); got == "" {
+		t.Fatal("expected New-Item -Path target extraction to succeed")
 	}
 }
 

--- a/internal/tool/implementations_test.go
+++ b/internal/tool/implementations_test.go
@@ -20,7 +20,7 @@ func TestReadFileTool_PartialRead(t *testing.T) {
 	// constant setup
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test.txt")
-		filePath = filepath.ToSlash(filePath)
+	filePath = filepath.ToSlash(filePath)
 	content := "line1\nline2\nline3\nline4\nline5\n"
 	err := os.WriteFile(filePath, []byte(content), 0644)
 	if err != nil {
@@ -129,9 +129,9 @@ func TestReadFileTool_OutputTruncation(t *testing.T) {
 }
 
 func TestBashTool_Execute(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Unix echo/pwd behavior tests skipped on Windows; see TestPSShellTool_* in implementations_cmd_test.go")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix echo/pwd behavior tests skipped on Windows; see TestPSShellTool_* in implementations_cmd_test.go")
+	}
 	tests := []struct {
 		name    string
 		params  json.RawMessage
@@ -198,9 +198,9 @@ func TestBashTool_Execute(t *testing.T) {
 }
 
 func TestBashTool_CWDParameter(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Unix pwd/path tests skipped on Windows")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix pwd/path tests skipped on Windows")
+	}
 	// Create a subdirectory within the current working directory
 	// Use a subdirectory of the package directory to ensure it's within allowed paths
 	tmpDir := filepath.Join("internal", "tool", "test_cwd")
@@ -224,9 +224,9 @@ func TestBashTool_CWDParameter(t *testing.T) {
 }
 
 func TestBashTool_MultipleArgs(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Unix echo multi-arg test skipped on Windows; see TestPSShellTool_* in implementations_cmd_test.go")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix echo multi-arg test skipped on Windows; see TestPSShellTool_* in implementations_cmd_test.go")
+	}
 	tool := ShellTool{}
 
 	// Test with multiple arguments
@@ -245,9 +245,9 @@ func TestBashTool_MultipleArgs(t *testing.T) {
 }
 
 func TestBashTool_OutputTruncation(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("seq command not available on Windows")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("seq command not available on Windows")
+	}
 	tool := ShellTool{}
 
 	// Create a command that outputs more than 1024 lines
@@ -271,9 +271,9 @@ func TestBashTool_OutputTruncation(t *testing.T) {
 }
 
 func TestBashTool_UnsafeCWD(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Unix /tmp path test skipped on Windows")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix /tmp path test skipped on Windows")
+	}
 	tool := ShellTool{}
 
 	// Try to use an unsafe cwd (outside CWD)
@@ -594,13 +594,13 @@ func TestBashTool_RequiresConfirmation(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "non-whitelisted command mkdir (removed from whitelist)",
-			params:   json.RawMessage(`{"command": "mkdir test"}`),
+			name:     "existing mkdir target still prompts",
+			params:   json.RawMessage(`{"command": "mkdir ."}`),
 			expected: true,
 		},
 		{
-			name:     "non-whitelisted command touch (removed from whitelist)",
-			params:   json.RawMessage(`{"command": "touch file.txt"}`),
+			name:     "existing touch target still prompts",
+			params:   json.RawMessage(`{"command": "touch implementations.go"}`),
 			expected: true,
 		},
 		// Invalid input

--- a/internal/tool/permissions.go
+++ b/internal/tool/permissions.go
@@ -6,6 +6,57 @@ import (
 	"strings"
 )
 
+// isNewPath returns true when the resolved target path does not yet exist,
+// falls within the project root, and stays within the provided session cwd.
+// Creation outside the project root or outside the active cwd always prompts.
+func isNewPath(path string, cwd string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+
+	baseDir := strings.TrimSpace(cwd)
+	if baseDir == "" {
+		var err error
+		baseDir, err = os.Getwd()
+		if err != nil {
+			return false
+		}
+	}
+
+	absBaseDir, err := filepath.Abs(baseDir)
+	if err != nil {
+		return false
+	}
+	if evalBaseDir, err := filepath.EvalSymlinks(absBaseDir); err == nil {
+		absBaseDir = evalBaseDir
+	}
+
+	resolvedPath := path
+	if !filepath.IsAbs(resolvedPath) {
+		resolvedPath = filepath.Join(absBaseDir, resolvedPath)
+	}
+	absPath, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return false
+	}
+
+	if !IsSafePath(absPath) {
+		return false
+	}
+
+	relToBase, err := filepath.Rel(absBaseDir, absPath)
+	if err != nil {
+		return false
+	}
+	if relToBase == ".." || strings.HasPrefix(relToBase, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	_, err = os.Stat(absPath)
+	return os.IsNotExist(err)
+}
+
 // IsSafePath checks if a path is within the current working directory.
 func IsSafePath(path string) bool {
 	// Shortcut: If the path is relative and does not contain ".." components,

--- a/internal/tool/permissions.go
+++ b/internal/tool/permissions.go
@@ -6,6 +6,41 @@ import (
 	"strings"
 )
 
+// canonicalizePath resolves symlinks for the nearest existing ancestor of absPath
+// and then reapplies the non-existing suffix. This gives a canonical target path
+// even when the leaf does not exist yet.
+func canonicalizePath(absPath string) (string, error) {
+	absPath = filepath.Clean(absPath)
+	current := absPath
+
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolvedCurrent, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+
+			suffix, err := filepath.Rel(current, absPath)
+			if err != nil {
+				return "", err
+			}
+			if suffix == "." {
+				return filepath.Clean(resolvedCurrent), nil
+			}
+
+			return filepath.Clean(filepath.Join(resolvedCurrent, suffix)), nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	return filepath.Clean(absPath), nil
+}
+
 // isNewPath returns true when the resolved target path does not yet exist,
 // falls within the project root, and stays within the provided session cwd.
 // Creation outside the project root or outside the active cwd always prompts.
@@ -40,12 +75,16 @@ func isNewPath(path string, cwd string) bool {
 	if err != nil {
 		return false
 	}
-
-	if !IsSafePath(absPath) {
+	canonicalPath, err := canonicalizePath(absPath)
+	if err != nil {
 		return false
 	}
 
-	relToBase, err := filepath.Rel(absBaseDir, absPath)
+	if !IsSafePath(canonicalPath) {
+		return false
+	}
+
+	relToBase, err := filepath.Rel(absBaseDir, canonicalPath)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## PR Title
Harden shell approval path handling and reduce unnecessary Windows confirmations

## Summary
This PR narrows scope to two focused areas:

1. **Path safety hardening for shell auto-approval**
2. **Windows-specific confirmation policy improvements**

It intentionally excludes unrelated work (subagent init changes and Unix native-first shell execution routing).

---

## What This PR Changes

### 1) Path hardening for shell auto-approval
- Tightens auto-approval so it applies only to safe, constrained creation flows.
- Improves path handling to avoid approval bypass via ambiguous or expansion-prone targets.
- Keeps approval conservative when command intent is unclear.

Key outcomes:
- Safer handling of path-based command approval decisions.
- Reduced risk of approving commands that rely on shell expansion/ambiguity.

---

### 2) Windows confirmation policy: less noisy, still conservative
- Replaces “always prompt” behavior with **selective auto-approval** for clearly safe/read-only PowerShell commands.
- Introduces risky-command/syntax checks that still force explicit confirmation.
- Adds parser-backed command classification for more reliable decision-making.
- Supports simple new-path creation carveouts where policy allows.

Key outcomes:
- Fewer unnecessary prompts on Windows for benign commands.
- Maintains explicit confirmation for risky/mutating or unclear command shapes.

---

## Scope Clarification
This PR **does not** include:
- Subagent lazy init / retry changes
- Unix native-first execution/fallback refactor
- Temporary tracing instrumentation used during local verification

---

## Files Changed
- `internal/tool/implementations.go`
- `internal/tool/permissions.go`
- `internal/tool/implementations_test.go`
- `internal/tool/implementations_bash_test.go`
- `internal/tool/implementations_cmd_test.go`

---

## Validation

### Automated
- `go test ./internal/tool` ✅
- `GOOS=windows GOARCH=amd64 go test -c ./internal/tool` ✅ (Windows compile-path validation)

### Behavioral checks covered by tests
- Path auto-approval hardening behavior
- Expansion/ambiguous target rejection in auto-approval extraction
- Windows selective confirmation behavior
- Windows parser-backed command extraction/classification
- Windows new-path carveout behavior

---

## Why This Matters
- Improves shell safety posture without over-broad prompt fatigue.
- Keeps approval policy predictable and conservative.
- Improves day-to-day UX on Windows while preserving explicit confirmation boundaries.