### PR TITLE
feat(approval): add once/session/project scopes with decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Standard AI coding assistants dump massive contexts into a single window, leading to token bloat, amnesia, hallucinations and degraded ability. **Late solves this by mirroring real engineering teams:** a Lead Architect orchestrator maps the codebase and spawns ephemeral, isolated subagents to execute perfect, exact-match code edits.
 
-![Late Orchestrator planning a 4-phase implementation and spawning the first subagent](assets/late-subagent-handoff.png)
-*Late acting as Lead Architect: Orchestrating a 4-phase plan and autonomously spawning atomic subagents.*
+![Late Orchestrator planning a multi-phase implementation and spawning the first subagent](assets/late-subagent-handoff.png)
+*Late acting as Lead Architect: Orchestrating a multi-phase plan and autonomously spawning atomic subagents.*
 
 > **Built with Late:** As of today, the vast majority of Late is being built *inside* Late.
 
@@ -44,7 +44,7 @@ A statically compiled engine. No `node_modules`, no virtual environments, no blo
 
 ### 6. Local-First & Model Agnostic
 
-Requires any OpenAI-compatible endpoint. Late's ephemeral subagent architecture is designed for consumer hardware: subagent contexts are destroyed on completion and never pollute the planner's window, keeping VRAM and context usage flat regardless of task complexity. Late orchestrates its own codebase development on **5GB VRAM** using a local `Qwen3.5-35B-A3B` (~30 tokens/sec through `llama.cpp`, 65k context, remaining layers offloaded to system RAM). Two simultaneous agent instances run comfortably at ~15 t/s.
+Requires any OpenAI-compatible endpoint. Late's ephemeral subagent architecture is designed for consumer hardware: subagent contexts are destroyed on completion and never pollute the planner's window, keeping VRAM and context usage flat regardless of task complexity. Late orchestrates its own codebase development on **5GB VRAM** using a local `Qwen3.6-35B-A3B` (~30 tokens/sec through `llama.cpp`, 65k context, remaining layers offloaded to system RAM). Two simultaneous agent instances run comfortably at ~15 t/s.
 Natively supports both thinking and non-thinking models (including extra support for `Gemma 4`), or can be pointed at heavy-compute cloud endpoints for complex architectural tasks.
 
 ## 🚀 Quick Start (Zero Dependencies)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -89,13 +89,20 @@ Late will read your codebase, plan the implementation, and ask you for approval.
 When the agent wants to run a command or edit a file, you'll see a confirmation prompt:
 
 ```
-The agent wants to execute bash.
-  {"command": "go test ./..."}
-> Press [ y ] to Approve  |  [ n ] to Deny
+The agent wants to execute list_projects.
+  {}
+> Press [y] Allow once | [s] Always: session | [p] Always: project | [g] Always: global | [n] Deny
 ```
 
 - **Read-only commands** (`ls`, `cat`, `grep`, etc.) are auto-approved for speed (Note: the listed commands can still require permission if Late deems the agents activity suspicious)
-- **Everything else** requires your explicit `y` / `n`.
+- **Everything else** requires explicit approval.
+- Use **`[y] Allow once`** to approve only this single tool call.
+- Use **`[s] Always: session`** to auto-approve matching requests for the rest of the current session.
+- Use **`[p] Always: project`** to remember approval for this project.
+- Use **`[g] Always: global`** to remember approval across all projects on this machine.
+- Use **`[n] Deny`** to block the request.
+
+This keeps one-off actions safe while reducing repetitive prompts when you trust a tool in a broader scope.
 
 ## Configuration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,6 +104,22 @@ The agent wants to execute list_projects.
 
 This keeps one-off actions safe while reducing repetitive prompts when you trust a tool in a broader scope.
 
+### Permission Decay (TTL)
+
+"Always" approvals are not permanent. Late uses TTL (time-to-live) so trust decays over time:
+
+- **Session scope** (`[s]`) lasts **30 minutes**.
+- **Project scope** (`[p]`) lasts **30 days**.
+- **Global scope** (`[g]`) lasts **30 days**.
+
+When a TTL expires, the approval is automatically ignored and Late will prompt you again. This is intentional: it reduces long-lived stale permissions while keeping day-to-day workflows smooth.
+
+Notes:
+
+- Re-approving a tool/command in the same scope refreshes its TTL.
+- Session approvals are in-memory and expire quickly by design.
+- Project/global approvals are persisted with an expiry timestamp and checked at load time.
+
 ## Configuration
 
 You can set your preferred model selection (orchestrator, subagents) and their respective configuration (host, keys) permanently inside the `config.json`.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -220,6 +220,40 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
+// RefreshContextSize re-probes the backend properties to update the context size if it's llama.cpp.
+func (c *Client) RefreshContextSize(ctx context.Context) {
+	c.mu.RLock()
+	isLlama := c.backend == BackendLlamaCPP
+	c.mu.RUnlock()
+	if !isLlama {
+		return
+	}
+
+	url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/props"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return
+	}
+	if c.cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var props PropsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&props); err == nil {
+			c.mu.Lock()
+			c.ctxSize = props.DefaultGenerationSettings.NCtx
+			c.mu.Unlock()
+		}
+	}
+}
+
 // DiscoverBackend probes certain endpoints to identify the inference engine.
 func (c *Client) DiscoverBackend(ctx context.Context) BackendType {
 	c.mu.RLock()

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -24,6 +24,8 @@ type Orchestrator interface {
 	Context() context.Context
 	Middlewares() []ToolMiddleware
 	Registry() *ToolRegistry
+	SystemPrompt() string
+	ToolDefinitions() []client.ToolDefinition
 
 	// Hierarchy
 	Children() []Orchestrator
@@ -31,6 +33,7 @@ type Orchestrator interface {
 
 	// Configuration
 	SetMaxTurns(int)
+	RefreshContextSize(context.Context)
 	MaxTokens() int
 }
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -14,37 +14,49 @@ func ReplacePlaceholders(text string, placeholders map[string]string) string {
 }
 
 // EstimateTokenCount estimates the number of tokens in text.
-// Uses a simple approximation: 1 token ≈ 4 characters.
+// Uses a refined approximation: 1 token ≈ 3.5 characters (more accurate for code/English mix).
 func EstimateTokenCount(text string) int {
 	if text == "" {
 		return 0
 	}
-	// A common rule of thumb for English and code: 4 characters per token.
-	return (len(text) + 3) / 4
+	return int(float64(len(text)) / 3.5)
 }
 
-// EstimateMessageTokens estimates tokens for a full chat message including tool calls.
+// EstimateToolDefinitionTokens estimates tokens used by tool definitions.
+func EstimateToolDefinitionTokens(tools []client.ToolDefinition) int {
+	if len(tools) == 0 {
+		return 0
+	}
+	// Simplified: estimate based on JSON representation overhead
+	total := 0
+	for _, t := range tools {
+		total += EstimateTokenCount(t.Function.Name) + EstimateTokenCount(t.Function.Description)
+		// Parameters are more complex, but we can estimate them too
+		total += len(t.Function.Parameters) / 4
+	}
+	return total + 10 // Base overhead for tools block
+}
+
+// EstimateMessageTokens estimates tokens for a full chat message including tool calls and role overhead.
 func EstimateMessageTokens(msg client.ChatMessage) int {
 	tokens := EstimateTokenCount(msg.Content) + EstimateTokenCount(msg.ReasoningContent)
 	for _, tc := range msg.ToolCalls {
 		tokens += EstimateTokenCount(tc.Function.Name) + EstimateTokenCount(tc.Function.Arguments)
 	}
-	return tokens
+	// Per-message overhead for roles and delimiters (approx 4 tokens)
+	return tokens + 4
 }
 
-// EstimateEventTokens estimates tokens for a content event, including streamed tool calls.
+// EstimateEventTokens estimates tokens for a content event.
 func EstimateEventTokens(event ContentEvent) int {
-	tokens := EstimateTokenCount(event.Content) + EstimateTokenCount(event.ReasoningContent)
-	for _, tc := range event.ToolCalls {
-		tokens += EstimateTokenCount(tc.Function.Name) + EstimateTokenCount(tc.Function.Arguments)
-	}
-	return tokens
+	return EstimateTokenCount(event.Content) + EstimateTokenCount(event.ReasoningContent)
 }
 
-// CalculateHistoryTokens calculates the total token count from a slice of chat messages.
-// It iterates through all messages and sums up their individual token estimates.
-func CalculateHistoryTokens(history []client.ChatMessage) int {
-	total := 0
+// CalculateHistoryTokens calculates the total token count from history, system prompt, and tools.
+func CalculateHistoryTokens(history []client.ChatMessage, systemPrompt string, tools []client.ToolDefinition) int {
+	total := EstimateTokenCount(systemPrompt) + 10 // System prompt + overhead
+	total += EstimateToolDefinitionTokens(tools)
+
 	for _, msg := range history {
 		total += EstimateMessageTokens(msg)
 	}

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -42,11 +42,13 @@ func TestEstimateTokenCount(t *testing.T) {
 		expected int
 	}{
 		{"", 0},
-		{"a", 1},    // (1+3)/4 = 1
-		{"abcd", 1}, // (4+3)/4 = 1
-		{"abcde", 2}, // (5+3)/4 = 2 (rounding up)
-		{"12345678", 2}, // (8+3)/4 = 2
-		{"123456789", 3}, // (9+3)/4 = 3
+		{"a", 0},        // 1/3.5 = 0.28 -> 0
+		{"abcd", 1},     // 4/3.5 = 1.14 -> 1
+		{"abcde", 1},    // 5/3.5 = 1.42 -> 1
+		{"12345678", 2}, // 8/3.5 = 2.28 -> 2
+		{"123456789", 2}, // 9/3.5 = 2.57 -> 2
+		{"1234567890", 2}, // 10/3.5 = 2.85 -> 2
+		{"this is a test", 4}, // 14/3.5 = 4.0 -> 4
 	}
 
 	for _, tt := range tests {
@@ -72,12 +74,13 @@ func TestEstimateMessageTokens(t *testing.T) {
 		},
 	}
 
-	// "Hello" = 5 chars -> 2 tokens
+	// "Hello" = 5 chars -> 1 token
 	// "Thinking..." = 11 chars -> 3 tokens
-	// "test_tool" = 9 chars -> 3 tokens
+	// "test_tool" = 9 chars -> 2 tokens
 	// `{"arg1": "val1"}` = 16 chars -> 4 tokens
-	// Total = 2 + 3 + 3 + 4 = 12 tokens
-	expected := 12
+	// Message overhead = 4 tokens
+	// Total = 1 + 3 + 2 + 4 + 4 = 14 tokens
+	expected := 14
 	result := EstimateMessageTokens(msg)
 	if result != expected {
 		t.Errorf("EstimateMessageTokens() = %d; want %d", result, expected)
@@ -88,22 +91,12 @@ func TestEstimateEventTokens(t *testing.T) {
 	event := ContentEvent{
 		Content:          "Part1",
 		ReasoningContent: "Reason",
-		ToolCalls: []client.ToolCall{
-			{
-				Function: client.FunctionCall{
-					Name:      "tool",
-					Arguments: "{}",
-				},
-			},
-		},
 	}
 
-	// "Part1" = 5 chars -> 2 tokens
-	// "Reason" = 6 chars -> 2 tokens
-	// "tool" = 4 chars -> 1 token
-	// "{}" = 2 chars -> 1 token
-	// Total = 2 + 2 + 1 + 1 = 6 tokens
-	expected := 6
+	// "Part1" = 5 chars -> 1 token
+	// "Reason" = 6 chars -> 1 token
+	// Total = 1 + 1 = 2 tokens
+	expected := 2
 	result := EstimateEventTokens(event)
 	if result != expected {
 		t.Errorf("EstimateEventTokens() = %d; want %d", result, expected)
@@ -112,110 +105,36 @@ func TestEstimateEventTokens(t *testing.T) {
 
 func TestCalculateHistoryTokens(t *testing.T) {
 	tests := []struct {
-		name     string
-		history  []client.ChatMessage
-		expected int
+		name         string
+		history      []client.ChatMessage
+		systemPrompt string
+		tools        []client.ToolDefinition
+		expected     int
 	}{
 		{
-			name:     "empty history returns 0",
-			history:  []client.ChatMessage{},
-			expected: 0,
+			name:         "empty history with system prompt",
+			history:      []client.ChatMessage{},
+			systemPrompt: "You are an assistant",
+			tools:        nil,
+			expected:     15, // "You are an assistant" = 20 chars -> 5 tokens + 10 overhead = 15
 		},
 		{
-			name:     "nil history returns 0",
-			history:  nil,
-			expected: 0,
-		},
-		{
-			name: "single message with content",
+			name: "single user message",
 			history: []client.ChatMessage{
 				{
 					Role:    "user",
 					Content: "Hello",
 				},
 			},
-			expected: 2, // "Hello" = 5 chars -> 2 tokens
-		},
-		{
-			name: "single message with reasoning content",
-			history: []client.ChatMessage{
-				{
-					Role:             "assistant",
-					Content:          "Here's the answer",
-					ReasoningContent: "Let me think about this...",
-				},
-			},
-			expected: 12, // "Here's the answer" = 17 chars -> 5 tokens, "Let me think about this..." = 26 chars -> 7 tokens, total = 12 tokens
-		},
-		{
-			name: "multiple messages sum correctly",
-			history: []client.ChatMessage{
-				{
-					Role:    "user",
-					Content: "What is 2+2?",
-				},
-				{
-					Role:             "assistant",
-					Content:          "2+2 equals 4",
-					ReasoningContent: "Simple math",
-				},
-			},
-			expected: 9, // "What is 2+2?" = 12 chars -> 3 tokens, "2+2 equals 4" = 12 chars -> 3 tokens, "Simple math" = 11 chars -> 3 tokens, total = 9 tokens
-		},
-		{
-			name: "message with tool calls included",
-			history: []client.ChatMessage{
-				{
-					Role:    "user",
-					Content: "Call the tool",
-				},
-				{
-					Role:    "assistant",
-					Content: "",
-					ToolCalls: []client.ToolCall{
-						{
-							Function: client.FunctionCall{
-								Name:      "calculate",
-								Arguments: `{"a": 5, "b": 3}`,
-							},
-						},
-					},
-				},
-			},
-			expected: 11, // "Call the tool" = 13 chars -> 4 tokens, "calculate" = 9 chars -> 3 tokens, `{"a": 5, "b": 3}` = 15 chars -> 4 tokens, total = 11 tokens
-		},
-		{
-			name: "mixed messages with all content types",
-			history: []client.ChatMessage{
-				{
-					Role:    "user",
-					Content: "Hello",
-				},
-				{
-					Role:             "assistant",
-					Content:          "Hi there",
-					ReasoningContent: "Thinking...",
-					ToolCalls: []client.ToolCall{
-						{
-							Function: client.FunctionCall{
-								Name:      "greet",
-								Arguments: `{"name": "user"}`,
-							},
-						},
-					},
-				},
-				{
-					Role:    "user",
-					Content: "How are you?",
-				},
-			},
-			expected: 16, // "Hello" = 5 chars -> 2 tokens, "Hi there" = 8 chars -> 2 tokens, "Thinking..." = 11 chars -> 3 tokens, "greet" = 5 chars -> 2 tokens, `{"name": "user"}` = 16 chars -> 4 tokens, "How are you?" = 12 chars -> 3 tokens, total = 16 tokens
+			systemPrompt: "",
+			tools:        nil,
+			expected:     15, // System overhead (10) + msg content (1) + msg overhead (4) = 15
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CalculateHistoryTokens(tt.history)
+			result := CalculateHistoryTokens(tt.history, tt.systemPrompt, tt.tools)
 			if result != tt.expected {
 				t.Errorf("CalculateHistoryTokens() = %d; want %d", result, tt.expected)
 			}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -78,6 +78,21 @@ func ExecuteToolCalls(ctx context.Context, sess *session.Session, toolCalls []cl
 	}
 
 	for _, tc := range toolCalls {
+		// Fail-closed: if no confirmation middleware is provided, do not
+		// execute shell commands (they must be explicitly approved by a
+		// middleware such as the TUI confirm middleware).
+		if len(middlewares) == 0 {
+			if t := sess.Registry.Get(tc.Function.Name); t != nil {
+				if _, ok := t.(*tool.ShellTool); ok {
+					result := "shell command requires explicit approval before execution"
+					if err := sess.AddToolResultMessage(tc.ID, result); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+		}
+
 		result, err := runner(ctx, tc)
 		if err != nil {
 			result = fmt.Sprintf("Error executing tool %s: %v", tc.Function.Name, err)

--- a/internal/orchestrator/base.go
+++ b/internal/orchestrator/base.go
@@ -68,6 +68,10 @@ func (o *BaseOrchestrator) MaxTokens() int {
 	return o.sess.Client().ContextSize()
 }
 
+func (o *BaseOrchestrator) RefreshContextSize(ctx context.Context) {
+	o.sess.Client().RefreshContextSize(ctx)
+}
+
 func (o *BaseOrchestrator) ID() string { return o.id }
 
 func (o *BaseOrchestrator) Submit(text string) error {
@@ -118,6 +122,7 @@ func (o *BaseOrchestrator) Execute(text string) (string, error) {
 	var extraBody map[string]any
 
 	onStartTurn := func() {
+		o.RefreshContextSize(ctx)
 		o.mu.Lock()
 		o.acc.Reset()
 		o.mu.Unlock()
@@ -125,6 +130,7 @@ func (o *BaseOrchestrator) Execute(text string) (string, error) {
 	}
 
 	onEndTurn := func() {
+		o.RefreshContextSize(ctx)
 		o.mu.Lock()
 		usage := o.acc.Usage
 		o.acc.Reset()
@@ -183,6 +189,7 @@ func (o *BaseOrchestrator) run() {
 	ctx = context.WithValue(ctx, common.OrchestratorIDKey, o.id)
 
 	onStartTurn := func() {
+		o.RefreshContextSize(ctx)
 		o.mu.Lock()
 		o.acc.Reset()
 		o.mu.Unlock()
@@ -190,6 +197,7 @@ func (o *BaseOrchestrator) run() {
 	}
 
 	onEndTurn := func() {
+		o.RefreshContextSize(ctx)
 		o.mu.Lock()
 		usage := o.acc.Usage
 		o.acc.Reset()
@@ -273,6 +281,14 @@ func (o *BaseOrchestrator) History() []client.ChatMessage {
 
 func (o *BaseOrchestrator) Session() *session.Session {
 	return o.sess
+}
+
+func (o *BaseOrchestrator) SystemPrompt() string {
+	return o.sess.SystemPrompt()
+}
+
+func (o *BaseOrchestrator) ToolDefinitions() []client.ToolDefinition {
+	return o.sess.GetToolDefinitions()
 }
 
 func (o *BaseOrchestrator) Context() context.Context {

--- a/internal/tool/bash_analyzer.go
+++ b/internal/tool/bash_analyzer.go
@@ -95,72 +95,30 @@ func (b *BashAnalyzer) Analyze(command string) CommandAnalysis {
 
 	analysis := CommandAnalysis{}
 
-	var checkNode func(node syntax.Node) bool
-	checkNode = func(node syntax.Node) bool {
-		if node == nil {
-			return true
+	syntax.Walk(f, func(node syntax.Node) bool {
+		if node == nil || analysis.IsBlocked {
+			return false
 		}
+
 		switch n := node.(type) {
 		case *syntax.CallExpr:
 			if !b.isSafeCall(n, &analysis) {
 				analysis.NeedsConfirmation = true
 			}
-			if analysis.IsBlocked {
-				return false
-			}
-
 		case *syntax.Redirect:
 			switch n.Op {
 			case syntax.RdrOut, syntax.AppOut, syntax.RdrAll, syntax.AppAll, syntax.RdrClob, syntax.AppClob, syntax.DplOut:
 				analysis.IsBlocked = true
 				analysis.NeedsConfirmation = true
 				analysis.BlockReason = fmt.Errorf("Output redirection (>) is blocked. Use `write_file` or `target_edit` to modify files.")
-				return false
 			}
-
-		case *syntax.BinaryCmd:
-			if !checkNode(n.X) || !checkNode(n.Y) {
-				return false
-			}
-
-		case *syntax.Stmt:
-			for _, redir := range n.Redirs {
-				if !checkNode(redir) {
-					return false
-				}
-			}
-			if !checkNode(n.Cmd) {
-				return false
-			}
-
-		case *syntax.File:
-			for _, stmt := range n.Stmts {
-				if !checkNode(stmt) {
-					return false
-				}
-			}
-
-		case *syntax.Block:
-			for _, stmt := range n.Stmts {
-				if !checkNode(stmt) {
-					return false
-				}
-			}
-			analysis.NeedsConfirmation = true
-
-		case *syntax.CmdSubst, *syntax.Subshell, *syntax.ProcSubst:
-			analysis.NeedsConfirmation = true
-
-		case *syntax.IfClause, *syntax.WhileClause, *syntax.ForClause, *syntax.CaseClause:
-			analysis.NeedsConfirmation = true
-
-		case *syntax.ParamExp:
+		case *syntax.Block, *syntax.CmdSubst, *syntax.Subshell, *syntax.ProcSubst,
+			*syntax.IfClause, *syntax.WhileClause, *syntax.ForClause, *syntax.CaseClause, *syntax.ParamExp:
 			analysis.NeedsConfirmation = true
 		}
-		return true
-	}
 
-	checkNode(f)
+		return !analysis.IsBlocked
+	})
 
 	return analysis
 }

--- a/internal/tool/bash_analyzer_test.go
+++ b/internal/tool/bash_analyzer_test.go
@@ -33,6 +33,8 @@ func TestAnalyzeBashCommand(t *testing.T) {
 		{"Whitelisted list", "ls; pwd", false, false},
 		{"Non-whitelisted command", "mkdir foo", false, true},
 		{"Combined cd & ls (blocked)", "cd /tmp; ls", true, true},
+		{"Nested cd in if (blocked)", "if true; then cd /tmp; fi", true, true},
+		{"Nested redirect in cmdsubst (blocked)", "echo $(ls > out.txt)", true, true},
 		{"Variable expansion (needs confirm)", "echo $HOME", false, true},
 		{"Path-based command (blocked)", "/bin/ls", false, true},
 		{"Git status (auto-approve)", "git status", false, false},

--- a/internal/tool/permissions.go
+++ b/internal/tool/permissions.go
@@ -2,10 +2,13 @@ package tool
 
 import (
 	"encoding/json"
+	"late/internal/common"
 	"late/internal/pathutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 )
 
 // canonicalizePath resolves symlinks for the nearest existing ancestor of absPath
@@ -170,9 +173,126 @@ func IsSafePath(path string) bool {
 const (
 	localAllowedCommandsFile = ".late/allowed_commands.json"
 	localAllowedToolsFile    = ".late/allowed_tools.json"
-	commandsFileName        = "allowed_commands.json"
-	toolsFileName           = "allowed_tools.json"
+	commandsFileName         = "allowed_commands.json"
+	toolsFileName            = "allowed_tools.json"
+	projectApprovalTTL       = 30 * 24 * time.Hour
+	globalApprovalTTL        = 30 * 24 * time.Hour
+	sessionApprovalTTL       = 30 * time.Minute
+	sessionBaseMarker        = "__base__"
 )
+
+type persistedCommandEntry struct {
+	Flags     []string `json:"flags"`
+	SavedAt   string   `json:"saved_at,omitempty"`
+	ExpiresAt string   `json:"expires_at,omitempty"`
+	Version   string   `json:"version,omitempty"`
+}
+
+type persistedCommandsFile struct {
+	Version string                           `json:"version,omitempty"`
+	Entries map[string]persistedCommandEntry `json:"entries"`
+}
+
+type persistedToolEntry struct {
+	SavedAt   string `json:"saved_at,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+	Version   string `json:"version,omitempty"`
+}
+
+type persistedToolsFile struct {
+	Version string                        `json:"version,omitempty"`
+	Entries map[string]persistedToolEntry `json:"entries"`
+}
+
+type sessionApproval struct {
+	expiresAt time.Time
+}
+
+var (
+	sessionApprovalsMu       sync.Mutex
+	sessionAllowedTools      = make(map[string]sessionApproval)
+	sessionAllowedCommandMap = make(map[string]map[string]sessionApproval)
+	nowFunc                  = time.Now
+)
+
+func parseRFC3339OrZero(s string) time.Time {
+	if strings.TrimSpace(s) == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+func isEntryValid(expiresAt time.Time, version string) bool {
+	if !expiresAt.IsZero() && nowFunc().After(expiresAt) {
+		return false
+	}
+	if strings.TrimSpace(version) != "" && version != common.Version {
+		return false
+	}
+	return true
+}
+
+func cleanupSessionAllowListLocked() {
+	now := nowFunc()
+	for toolName, entry := range sessionAllowedTools {
+		if now.After(entry.expiresAt) {
+			delete(sessionAllowedTools, toolName)
+		}
+	}
+
+	for cmd, flags := range sessionAllowedCommandMap {
+		for flag, entry := range flags {
+			if now.After(entry.expiresAt) {
+				delete(flags, flag)
+			}
+		}
+		if len(flags) == 0 {
+			delete(sessionAllowedCommandMap, cmd)
+		}
+	}
+}
+
+// SaveSessionAllowedCommand stores a command in session scope with auto-expiry.
+func SaveSessionAllowedCommand(command string) {
+	commands := ParseCommandsForAllowList(command)
+	if len(commands) == 0 {
+		return
+	}
+
+	sessionApprovalsMu.Lock()
+	defer sessionApprovalsMu.Unlock()
+	cleanupSessionAllowListLocked()
+
+	expiresAt := nowFunc().Add(sessionApprovalTTL)
+	for cmd, flags := range commands {
+		if _, ok := sessionAllowedCommandMap[cmd]; !ok {
+			sessionAllowedCommandMap[cmd] = make(map[string]sessionApproval)
+		}
+		if len(flags) == 0 {
+			sessionAllowedCommandMap[cmd][sessionBaseMarker] = sessionApproval{expiresAt: expiresAt}
+			continue
+		}
+		for _, flag := range flags {
+			sessionAllowedCommandMap[cmd][flag] = sessionApproval{expiresAt: expiresAt}
+		}
+	}
+}
+
+// SaveSessionAllowedTool stores a tool in session scope with auto-expiry.
+func SaveSessionAllowedTool(name string) {
+	if strings.TrimSpace(name) == "" {
+		return
+	}
+
+	sessionApprovalsMu.Lock()
+	defer sessionApprovalsMu.Unlock()
+	cleanupSessionAllowListLocked()
+	sessionAllowedTools[name] = sessionApproval{expiresAt: nowFunc().Add(sessionApprovalTTL)}
+}
 
 func getGlobalConfigPath(fileName string) string {
 	configDir, err := pathutil.LateConfigDir()
@@ -205,14 +325,36 @@ func LoadAllowedCommands(global bool) (map[string]map[string]bool, error) {
 		return nil, err
 	}
 
+	// Backward-compatible format: map[string][]string
 	var list map[string][]string
-	if err := json.Unmarshal(data, &list); err != nil {
+	if err := json.Unmarshal(data, &list); err == nil {
+		for cmd, flags := range list {
+			allowed[cmd] = make(map[string]bool)
+			for _, flag := range flags {
+				allowed[cmd][flag] = true
+			}
+		}
+		return allowed, nil
+	}
+
+	// New format with metadata and decay.
+	var file persistedCommandsFile
+	if err := json.Unmarshal(data, &file); err != nil {
 		return nil, err
 	}
 
-	for cmd, flags := range list {
-		allowed[cmd] = make(map[string]bool)
-		for _, flag := range flags {
+	for cmd, entry := range file.Entries {
+		entryVersion := entry.Version
+		if entryVersion == "" {
+			entryVersion = file.Version
+		}
+		if !isEntryValid(parseRFC3339OrZero(entry.ExpiresAt), entryVersion) {
+			continue
+		}
+		if _, ok := allowed[cmd]; !ok {
+			allowed[cmd] = make(map[string]bool)
+		}
+		for _, flag := range entry.Flags {
 			allowed[cmd][flag] = true
 		}
 	}
@@ -245,6 +387,18 @@ func LoadAllAllowedCommands() (map[string]map[string]bool, error) {
 		}
 	}
 
+	sessionApprovalsMu.Lock()
+	defer sessionApprovalsMu.Unlock()
+	cleanupSessionAllowListLocked()
+	for cmd, flags := range sessionAllowedCommandMap {
+		if _, exists := merged[cmd]; !exists {
+			merged[cmd] = make(map[string]bool)
+		}
+		for flag := range flags {
+			merged[cmd][flag] = true
+		}
+	}
+
 	return merged, nil
 }
 
@@ -269,16 +423,28 @@ func SaveAllowedCommand(command string, global bool) error {
 		}
 	}
 
-	serializable := make(map[string][]string)
+	file := persistedCommandsFile{
+		Version: common.Version,
+		Entries: make(map[string]persistedCommandEntry),
+	}
+	expiresAt := nowFunc().Add(projectApprovalTTL)
+	if global {
+		expiresAt = nowFunc().Add(globalApprovalTTL)
+	}
 	for cmd, flagMap := range allowed {
 		var flagList []string
 		for flag := range flagMap {
 			flagList = append(flagList, flag)
 		}
-		serializable[cmd] = flagList
+		file.Entries[cmd] = persistedCommandEntry{
+			Flags:     flagList,
+			SavedAt:   nowFunc().UTC().Format(time.RFC3339),
+			ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+			Version:   common.Version,
+		}
 	}
 
-	data, err := json.MarshalIndent(serializable, "", "  ")
+	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -308,13 +474,30 @@ func LoadAllowedTools(global bool) (map[string]bool, error) {
 		return nil, err
 	}
 
+	// Backward-compatible format: []string
 	var list []string
-	if err := json.Unmarshal(data, &list); err != nil {
+	if err := json.Unmarshal(data, &list); err == nil {
+		for _, tool := range list {
+			allowed[tool] = true
+		}
+		return allowed, nil
+	}
+
+	// New format with metadata and decay.
+	var file persistedToolsFile
+	if err := json.Unmarshal(data, &file); err != nil {
 		return nil, err
 	}
 
-	for _, tool := range list {
-		allowed[tool] = true
+	for toolName, entry := range file.Entries {
+		entryVersion := entry.Version
+		if entryVersion == "" {
+			entryVersion = file.Version
+		}
+		if !isEntryValid(parseRFC3339OrZero(entry.ExpiresAt), entryVersion) {
+			continue
+		}
+		allowed[toolName] = true
 	}
 
 	return allowed, nil
@@ -338,6 +521,13 @@ func LoadAllAllowedTools() (map[string]bool, error) {
 		}
 	}
 
+	sessionApprovalsMu.Lock()
+	defer sessionApprovalsMu.Unlock()
+	cleanupSessionAllowListLocked()
+	for t := range sessionAllowedTools {
+		merged[t] = true
+	}
+
 	return merged, nil
 }
 
@@ -350,12 +540,23 @@ func SaveAllowedTool(name string, global bool) error {
 
 	allowed[name] = true
 
-	var list []string
-	for tool := range allowed {
-		list = append(list, tool)
+	file := persistedToolsFile{
+		Version: common.Version,
+		Entries: make(map[string]persistedToolEntry),
+	}
+	expiresAt := nowFunc().Add(projectApprovalTTL)
+	if global {
+		expiresAt = nowFunc().Add(globalApprovalTTL)
+	}
+	for toolName := range allowed {
+		file.Entries[toolName] = persistedToolEntry{
+			SavedAt:   nowFunc().UTC().Format(time.RFC3339),
+			ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+			Version:   common.Version,
+		}
 	}
 
-	data, err := json.MarshalIndent(list, "", "  ")
+	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -373,7 +574,7 @@ func SaveAllowedTool(name string, global bool) error {
 func NormalizeCommandForAllowList(command string) string {
 	commands := ParseCommandsForAllowList(command)
 	for key := range commands {
-		return key 
+		return key
 	}
 	return ""
 }

--- a/internal/tool/permissions.go
+++ b/internal/tool/permissions.go
@@ -215,15 +215,15 @@ var (
 	nowFunc                  = time.Now
 )
 
-func parseRFC3339OrZero(s string) time.Time {
+func parseRFC3339OrZero(s string) (time.Time, bool) {
 	if strings.TrimSpace(s) == "" {
-		return time.Time{}
+		return time.Time{}, true
 	}
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
-		return time.Time{}
+		return time.Time{}, false
 	}
-	return t
+	return t, true
 }
 
 func isEntryValid(expiresAt time.Time, version string) bool {
@@ -309,6 +309,48 @@ func getFilePath(localPath string, fileName string, global bool) string {
 	return localPath
 }
 
+func loadPersistedCommandsFile(path string) (persistedCommandsFile, error) {
+	file := persistedCommandsFile{Entries: make(map[string]persistedCommandEntry)}
+	if path == "" {
+		return file, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return file, nil
+		}
+		return file, err
+	}
+
+	if err := json.Unmarshal(data, &file); err != nil || file.Entries == nil {
+		return persistedCommandsFile{Entries: make(map[string]persistedCommandEntry)}, nil
+	}
+
+	return file, nil
+}
+
+func loadPersistedToolsFile(path string) (persistedToolsFile, error) {
+	file := persistedToolsFile{Entries: make(map[string]persistedToolEntry)}
+	if path == "" {
+		return file, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return file, nil
+		}
+		return file, err
+	}
+
+	if err := json.Unmarshal(data, &file); err != nil || file.Entries == nil {
+		return persistedToolsFile{Entries: make(map[string]persistedToolEntry)}, nil
+	}
+
+	return file, nil
+}
+
 // LoadAllowedCommands loads allowed commands from either local or global allow-list.
 func LoadAllowedCommands(global bool) (map[string]map[string]bool, error) {
 	allowed := make(map[string]map[string]bool)
@@ -348,7 +390,8 @@ func LoadAllowedCommands(global bool) (map[string]map[string]bool, error) {
 		if entryVersion == "" {
 			entryVersion = file.Version
 		}
-		if !isEntryValid(parseRFC3339OrZero(entry.ExpiresAt), entryVersion) {
+		expiresAt, ok := parseRFC3339OrZero(entry.ExpiresAt)
+		if !ok || !isEntryValid(expiresAt, entryVersion) {
 			continue
 		}
 		if _, ok := allowed[cmd]; !ok {
@@ -395,6 +438,9 @@ func LoadAllAllowedCommands() (map[string]map[string]bool, error) {
 			merged[cmd] = make(map[string]bool)
 		}
 		for flag := range flags {
+			if flag == sessionBaseMarker {
+				continue
+			}
 			merged[cmd][flag] = true
 		}
 	}
@@ -409,16 +455,30 @@ func SaveAllowedCommand(command string, global bool) error {
 		return nil
 	}
 
-	allowed, err := LoadAllowedCommands(global)
+	path := getFilePath(localAllowedCommandsFile, commandsFileName, global)
+	existingFile, err := loadPersistedCommandsFile(path)
 	if err != nil {
 		return err
 	}
 
+	allowed, err := LoadAllowedCommands(global)
+	if err != nil {
+		return err
+	}
+	touched := make(map[string]bool)
+
 	for key, flags := range commands {
-		if _, exists := allowed[key]; !exists {
+		existingFlags, exists := allowed[key]
+		if !exists {
 			allowed[key] = make(map[string]bool)
+			touched[key] = true
+		} else if len(flags) == 0 && !touched[key] {
+			touched[key] = false
 		}
 		for _, flag := range flags {
+			if !exists || !existingFlags[flag] {
+				touched[key] = true
+			}
 			allowed[key][flag] = true
 		}
 	}
@@ -436,12 +496,18 @@ func SaveAllowedCommand(command string, global bool) error {
 		for flag := range flagMap {
 			flagList = append(flagList, flag)
 		}
-		file.Entries[cmd] = persistedCommandEntry{
+		entry := persistedCommandEntry{
 			Flags:     flagList,
 			SavedAt:   nowFunc().UTC().Format(time.RFC3339),
 			ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
 			Version:   common.Version,
 		}
+		if existingEntry, ok := existingFile.Entries[cmd]; ok && !touched[cmd] {
+			entry.SavedAt = existingEntry.SavedAt
+			entry.ExpiresAt = existingEntry.ExpiresAt
+			entry.Version = existingEntry.Version
+		}
+		file.Entries[cmd] = entry
 	}
 
 	data, err := json.MarshalIndent(file, "", "  ")
@@ -449,7 +515,6 @@ func SaveAllowedCommand(command string, global bool) error {
 		return err
 	}
 
-	path := getFilePath(localAllowedCommandsFile, commandsFileName, global)
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -494,7 +559,8 @@ func LoadAllowedTools(global bool) (map[string]bool, error) {
 		if entryVersion == "" {
 			entryVersion = file.Version
 		}
-		if !isEntryValid(parseRFC3339OrZero(entry.ExpiresAt), entryVersion) {
+		expiresAt, ok := parseRFC3339OrZero(entry.ExpiresAt)
+		if !ok || !isEntryValid(expiresAt, entryVersion) {
 			continue
 		}
 		allowed[toolName] = true
@@ -533,11 +599,18 @@ func LoadAllAllowedTools() (map[string]bool, error) {
 
 // SaveAllowedTool adds a tool name to the specified always-allowed list (local or global).
 func SaveAllowedTool(name string, global bool) error {
+	path := getFilePath(localAllowedToolsFile, toolsFileName, global)
+	existingFile, err := loadPersistedToolsFile(path)
+	if err != nil {
+		return err
+	}
+
 	allowed, err := LoadAllowedTools(global)
 	if err != nil {
 		return err
 	}
 
+	_, alreadyAllowed := allowed[name]
 	allowed[name] = true
 
 	file := persistedToolsFile{
@@ -549,11 +622,17 @@ func SaveAllowedTool(name string, global bool) error {
 		expiresAt = nowFunc().Add(globalApprovalTTL)
 	}
 	for toolName := range allowed {
-		file.Entries[toolName] = persistedToolEntry{
+		entry := persistedToolEntry{
 			SavedAt:   nowFunc().UTC().Format(time.RFC3339),
 			ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
 			Version:   common.Version,
 		}
+		if existingEntry, ok := existingFile.Entries[toolName]; ok && (toolName != name || alreadyAllowed) {
+			entry.SavedAt = existingEntry.SavedAt
+			entry.ExpiresAt = existingEntry.ExpiresAt
+			entry.Version = existingEntry.Version
+		}
+		file.Entries[toolName] = entry
 	}
 
 	data, err := json.MarshalIndent(file, "", "  ")
@@ -561,7 +640,6 @@ func SaveAllowedTool(name string, global bool) error {
 		return err
 	}
 
-	path := getFilePath(localAllowedToolsFile, toolsFileName, global)
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err

--- a/internal/tool/permissions_test.go
+++ b/internal/tool/permissions_test.go
@@ -73,6 +73,9 @@ func TestSessionCommandApproval_ActiveAndThenExpires(t *testing.T) {
 		if _, ok := allowed["wget"]; !ok {
 			t.Fatalf("expected wget to be allowed in session")
 		}
+		if allowed["wget"][sessionBaseMarker] {
+			t.Fatalf("expected internal session base marker to stay hidden from merged allowlist")
+		}
 
 		nowFunc = func() time.Time { return base.Add(sessionApprovalTTL + time.Second) }
 		allowed, err = LoadAllAllowedCommands()
@@ -139,6 +142,107 @@ func TestLoadAllowedCommands_RevalidatesByVersionAndExpiry(t *testing.T) {
 	})
 }
 
+func TestLoadAllowedCommands_InvalidExpiryFailsClosed(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		if err := os.MkdirAll(filepath.Dir(localAllowedCommandsFile), 0755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+
+		file := persistedCommandsFile{
+			Version: common.Version,
+			Entries: map[string]persistedCommandEntry{
+				"git log": {
+					Flags:     []string{"--oneline"},
+					ExpiresAt: "not-a-timestamp",
+					Version:   common.Version,
+				},
+			},
+		}
+		data, err := json.Marshal(file)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		if err := os.WriteFile(localAllowedCommandsFile, data, 0644); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		allowed, err := LoadAllowedCommands(false)
+		if err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+		if _, ok := allowed["git log"]; ok {
+			t.Fatalf("expected invalid expires_at entry to fail closed")
+		}
+	})
+}
+
+func TestSaveAllowedCommand_PreservesUntouchedEntryMetadata(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		if err := os.MkdirAll(filepath.Dir(localAllowedCommandsFile), 0755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+
+		originalSavedAt := base.Add(-2 * time.Hour).Format(time.RFC3339)
+		originalExpiresAt := base.Add(2 * time.Hour).Format(time.RFC3339)
+		file := persistedCommandsFile{
+			Version: common.Version,
+			Entries: map[string]persistedCommandEntry{
+				"git log": {
+					Flags:     []string{"--oneline"},
+					SavedAt:   originalSavedAt,
+					ExpiresAt: originalExpiresAt,
+					Version:   common.Version,
+				},
+			},
+		}
+		data, err := json.Marshal(file)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		if err := os.WriteFile(localAllowedCommandsFile, data, 0644); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		nowFunc = func() time.Time { return base }
+		if err := SaveAllowedCommand("grep foo bar", false); err != nil {
+			t.Fatalf("SaveAllowedCommand failed: %v", err)
+		}
+
+		updatedData, err := os.ReadFile(localAllowedCommandsFile)
+		if err != nil {
+			t.Fatalf("read failed: %v", err)
+		}
+		var updated persistedCommandsFile
+		if err := json.Unmarshal(updatedData, &updated); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+
+		gitLog := updated.Entries["git log"]
+		if gitLog.SavedAt != originalSavedAt {
+			t.Fatalf("expected untouched entry SavedAt to be preserved, got %q want %q", gitLog.SavedAt, originalSavedAt)
+		}
+		if gitLog.ExpiresAt != originalExpiresAt {
+			t.Fatalf("expected untouched entry ExpiresAt to be preserved, got %q want %q", gitLog.ExpiresAt, originalExpiresAt)
+		}
+
+		grep := updated.Entries["grep"]
+		if grep.SavedAt != base.Format(time.RFC3339) {
+			t.Fatalf("expected new entry SavedAt to be current time, got %q", grep.SavedAt)
+		}
+		if grep.ExpiresAt != base.Add(projectApprovalTTL).Format(time.RFC3339) {
+			t.Fatalf("expected new entry ExpiresAt to use project TTL, got %q", grep.ExpiresAt)
+		}
+	})
+}
+
 func TestSaveAllowedTool_PersistsMetadataFormat(t *testing.T) {
 	withTempCWD(t, func() {
 		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
@@ -172,6 +276,68 @@ func TestSaveAllowedTool_PersistsMetadataFormat(t *testing.T) {
 		}
 		if !allowed["read_file"] {
 			t.Fatalf("expected read_file to load from metadata format")
+		}
+	})
+}
+
+func TestSaveAllowedTool_PreservesUntouchedEntryMetadata(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		if err := os.MkdirAll(filepath.Dir(localAllowedToolsFile), 0755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+
+		originalSavedAt := base.Add(-2 * time.Hour).Format(time.RFC3339)
+		originalExpiresAt := base.Add(2 * time.Hour).Format(time.RFC3339)
+		file := persistedToolsFile{
+			Version: common.Version,
+			Entries: map[string]persistedToolEntry{
+				"read_file": {
+					SavedAt:   originalSavedAt,
+					ExpiresAt: originalExpiresAt,
+					Version:   common.Version,
+				},
+			},
+		}
+		data, err := json.Marshal(file)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		if err := os.WriteFile(localAllowedToolsFile, data, 0644); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		nowFunc = func() time.Time { return base }
+		if err := SaveAllowedTool("write_file", false); err != nil {
+			t.Fatalf("SaveAllowedTool failed: %v", err)
+		}
+
+		updatedData, err := os.ReadFile(localAllowedToolsFile)
+		if err != nil {
+			t.Fatalf("read failed: %v", err)
+		}
+		var updated persistedToolsFile
+		if err := json.Unmarshal(updatedData, &updated); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+
+		readFile := updated.Entries["read_file"]
+		if readFile.SavedAt != originalSavedAt {
+			t.Fatalf("expected untouched tool SavedAt to be preserved, got %q want %q", readFile.SavedAt, originalSavedAt)
+		}
+		if readFile.ExpiresAt != originalExpiresAt {
+			t.Fatalf("expected untouched tool ExpiresAt to be preserved, got %q want %q", readFile.ExpiresAt, originalExpiresAt)
+		}
+
+		writeFile := updated.Entries["write_file"]
+		if writeFile.SavedAt != base.Format(time.RFC3339) {
+			t.Fatalf("expected new tool SavedAt to be current time, got %q", writeFile.SavedAt)
+		}
+		if writeFile.ExpiresAt != base.Add(projectApprovalTTL).Format(time.RFC3339) {
+			t.Fatalf("expected new tool ExpiresAt to use project TTL, got %q", writeFile.ExpiresAt)
 		}
 	})
 }

--- a/internal/tool/permissions_test.go
+++ b/internal/tool/permissions_test.go
@@ -1,0 +1,177 @@
+package tool
+
+import (
+	"encoding/json"
+	"late/internal/common"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func withTempCWD(t *testing.T, fn func()) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("failed to chdir temp: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(orig)
+	}()
+	fn()
+}
+
+func resetApprovalState(now time.Time) {
+	sessionApprovalsMu.Lock()
+	defer sessionApprovalsMu.Unlock()
+	sessionAllowedTools = make(map[string]sessionApproval)
+	sessionAllowedCommandMap = make(map[string]map[string]sessionApproval)
+	nowFunc = func() time.Time { return now }
+}
+
+func TestSessionToolApproval_Expires(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		SaveSessionAllowedTool("read_file")
+		allowed, err := LoadAllAllowedTools()
+		if err != nil {
+			t.Fatalf("LoadAllAllowedTools error: %v", err)
+		}
+		if !allowed["read_file"] {
+			t.Fatalf("expected read_file to be allowed in session")
+		}
+
+		nowFunc = func() time.Time { return base.Add(sessionApprovalTTL + time.Second) }
+		allowed, err = LoadAllAllowedTools()
+		if err != nil {
+			t.Fatalf("LoadAllAllowedTools error after expiry: %v", err)
+		}
+		if allowed["read_file"] {
+			t.Fatalf("expected read_file session approval to expire")
+		}
+	})
+}
+
+func TestSessionCommandApproval_ActiveAndThenExpires(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		SaveSessionAllowedCommand("wget https://example.com")
+		allowed, err := LoadAllAllowedCommands()
+		if err != nil {
+			t.Fatalf("LoadAllAllowedCommands error: %v", err)
+		}
+		if _, ok := allowed["wget"]; !ok {
+			t.Fatalf("expected wget to be allowed in session")
+		}
+
+		nowFunc = func() time.Time { return base.Add(sessionApprovalTTL + time.Second) }
+		allowed, err = LoadAllAllowedCommands()
+		if err != nil {
+			t.Fatalf("LoadAllAllowedCommands error after expiry: %v", err)
+		}
+		if _, ok := allowed["wget"]; ok {
+			t.Fatalf("expected wget session approval to expire")
+		}
+	})
+}
+
+func TestLoadAllowedCommands_RevalidatesByVersionAndExpiry(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		if err := os.MkdirAll(filepath.Dir(localAllowedCommandsFile), 0755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+
+		file := persistedCommandsFile{
+			Version: common.Version,
+			Entries: map[string]persistedCommandEntry{
+				"git log": {
+					Flags:     []string{"--oneline"},
+					ExpiresAt: base.Add(time.Hour).Format(time.RFC3339),
+					Version:   common.Version,
+				},
+				"git status": {
+					Flags:     []string{"--porcelain"},
+					ExpiresAt: base.Add(-time.Hour).Format(time.RFC3339),
+					Version:   common.Version,
+				},
+				"go test": {
+					Flags:     []string{"-v"},
+					ExpiresAt: base.Add(time.Hour).Format(time.RFC3339),
+					Version:   "different-version",
+				},
+			},
+		}
+		data, err := json.Marshal(file)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		if err := os.WriteFile(localAllowedCommandsFile, data, 0644); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		allowed, err := LoadAllowedCommands(false)
+		if err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+		if !allowed["git log"]["--oneline"] {
+			t.Fatalf("expected valid entry to load")
+		}
+		if _, ok := allowed["git status"]; ok {
+			t.Fatalf("expected expired entry to be filtered")
+		}
+		if _, ok := allowed["go test"]; ok {
+			t.Fatalf("expected version-mismatched entry to be filtered")
+		}
+	})
+}
+
+func TestSaveAllowedTool_PersistsMetadataFormat(t *testing.T) {
+	withTempCWD(t, func() {
+		base := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+		resetApprovalState(base)
+		defer func() { nowFunc = time.Now }()
+
+		if err := SaveAllowedTool("read_file", false); err != nil {
+			t.Fatalf("SaveAllowedTool failed: %v", err)
+		}
+
+		data, err := os.ReadFile(localAllowedToolsFile)
+		if err != nil {
+			t.Fatalf("read failed: %v", err)
+		}
+
+		var parsed persistedToolsFile
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("expected metadata format, got unmarshal error: %v", err)
+		}
+		entry, ok := parsed.Entries["read_file"]
+		if !ok {
+			t.Fatalf("expected read_file entry in persisted file")
+		}
+		if entry.Version != common.Version {
+			t.Fatalf("expected version %q, got %q", common.Version, entry.Version)
+		}
+
+		allowed, err := LoadAllowedTools(false)
+		if err != nil {
+			t.Fatalf("LoadAllowedTools failed: %v", err)
+		}
+		if !allowed["read_file"] {
+			t.Fatalf("expected read_file to load from metadata format")
+		}
+	})
+}

--- a/internal/tui/interactions.go
+++ b/internal/tui/interactions.go
@@ -112,7 +112,7 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 			select {
 			case choice := <-resultCh:
 				switch choice {
-				case "y", "s", "S", "p", "P", "g", "G", "a", "A":
+				case "y", "s", "S", "p", "P", "g", "G":
 					if t := reg.Get(tc.Function.Name); t != nil {
 						if _, ok := t.(*tool.ShellTool); ok {
 							var params struct {
@@ -122,9 +122,9 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 								switch choice {
 								case "s", "S":
 									tool.SaveSessionAllowedCommand(params.Command)
-								case "p", "P", "a":
+								case "p", "P":
 									_ = tool.SaveAllowedCommand(params.Command, false)
-								case "g", "G", "A":
+								case "g", "G":
 									_ = tool.SaveAllowedCommand(params.Command, true)
 								}
 							}
@@ -132,9 +132,9 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 							switch choice {
 							case "s", "S":
 								tool.SaveSessionAllowedTool(tc.Function.Name)
-							case "p", "P", "a":
+							case "p", "P":
 								_ = tool.SaveAllowedTool(tc.Function.Name, false)
-							case "g", "G", "A":
+							case "g", "G":
 								_ = tool.SaveAllowedTool(tc.Function.Name, true)
 							}
 						}

--- a/internal/tui/interactions.go
+++ b/internal/tui/interactions.go
@@ -112,19 +112,30 @@ func TUIConfirmMiddleware(messenger Messenger, reg *common.ToolRegistry) common.
 			select {
 			case choice := <-resultCh:
 				switch choice {
-				case "y", "a", "A":
-					if choice == "a" || choice == "A" {
-						global := (choice == "A")
-						if t := reg.Get(tc.Function.Name); t != nil {
-							if _, ok := t.(*tool.ShellTool); ok {
-								var params struct {
-									Command string `json:"command"`
+				case "y", "s", "S", "p", "P", "g", "G", "a", "A":
+					if t := reg.Get(tc.Function.Name); t != nil {
+						if _, ok := t.(*tool.ShellTool); ok {
+							var params struct {
+								Command string `json:"command"`
+							}
+							if err := json.Unmarshal([]byte(tc.Function.Arguments), &params); err == nil {
+								switch choice {
+								case "s", "S":
+									tool.SaveSessionAllowedCommand(params.Command)
+								case "p", "P", "a":
+									_ = tool.SaveAllowedCommand(params.Command, false)
+								case "g", "G", "A":
+									_ = tool.SaveAllowedCommand(params.Command, true)
 								}
-								if err := json.Unmarshal([]byte(tc.Function.Arguments), &params); err == nil {
-									_ = tool.SaveAllowedCommand(params.Command, global)
-								}
-							} else {
-								_ = tool.SaveAllowedTool(tc.Function.Name, global)
+							}
+						} else {
+							switch choice {
+							case "s", "S":
+								tool.SaveSessionAllowedTool(tc.Function.Name)
+							case "p", "P", "a":
+								_ = tool.SaveAllowedTool(tc.Function.Name, false)
+							case "g", "G", "A":
+								_ = tool.SaveAllowedTool(tc.Function.Name, true)
 							}
 						}
 					}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -71,8 +71,8 @@ func NewModel(root common.Orchestrator, renderer *glamour.TermRenderer) Model {
 	// Initialize root state
 	history := root.History()
 	cumulativeTokens := 0
-	if history != nil && len(history) > 0 {
-		cumulativeTokens = common.CalculateHistoryTokens(history)
+	if history != nil && len(history) >= 0 {
+		cumulativeTokens = common.CalculateHistoryTokens(history, root.SystemPrompt(), root.ToolDefinitions())
 	}
 	m.AgentStates[root.ID()] = &AppState{
 		State:                initialState,

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -60,6 +60,7 @@ type AppState struct {
 	// History token cache
 	CachedHistoryTokens int // Cached total token count for completed history
 	CachedHistoryLen    int // History length when tokens were last computed
+	LastRealTokenCount  int // Last ground-truth token count from the API usage data
 
 	// Performance caches
 	LastStreamingContent string   // To avoid re-splitting if content hasn't changed
@@ -126,4 +127,21 @@ type SetMessengerMsg struct {
 // OrchestratorEventMsg is the bridge between Orchestrator goroutines and the TUI loop.
 type OrchestratorEventMsg struct {
 	Event common.Event
+}
+
+// FindOrchestrator recursively searches for an orchestrator by ID.
+func (m *Model) FindOrchestrator(id string) common.Orchestrator {
+	var search func(curr common.Orchestrator) common.Orchestrator
+	search = func(curr common.Orchestrator) common.Orchestrator {
+		if curr.ID() == id {
+			return curr
+		}
+		for _, child := range curr.Children() {
+			if res := search(child); res != nil {
+				return res
+			}
+		}
+		return nil
+	}
+	return search(m.Root)
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -232,19 +232,34 @@ func (m Model) updateChat(msg tea.Msg) (Model, tea.Cmd) {
 			s.Usage = event.Usage
 			if event.Usage.TotalTokens > 0 {
 				s.CumulativeTokenCount = event.Usage.TotalTokens
+				s.LastRealTokenCount = event.Usage.TotalTokens
+				s.CachedHistoryLen = len(m.Focused.History())
 			} else {
 				// Fallback to estimation if no real usage data yet
 				newContentTokens := common.EstimateEventTokens(event)
 
-				// Use cached history token count (only recalculate when history changes)
-				history := m.Focused.History()
-				if len(history) != s.CachedHistoryLen {
-					s.CachedHistoryTokens = common.CalculateHistoryTokens(history)
-					s.CachedHistoryLen = len(history)
+				orch := m.FindOrchestrator(event.ID)
+				if orch == nil {
+					orch = m.Focused
 				}
+				history := orch.History()
 
-				// Update cumulative count
-				s.CumulativeTokenCount = s.CachedHistoryTokens + newContentTokens
+				if s.LastRealTokenCount > 0 && len(history) >= s.CachedHistoryLen {
+					// Use last real count as baseline and add estimation for new content since then
+					baseline := s.LastRealTokenCount
+					// Add messages added since the last real count (e.g. the new user prompt)
+					for i := s.CachedHistoryLen; i < len(history); i++ {
+						baseline += common.EstimateMessageTokens(history[i])
+					}
+					s.CumulativeTokenCount = baseline + newContentTokens
+				} else {
+					// Full estimation fallback (accounting for system prompt and tools)
+					if len(history) != s.CachedHistoryLen {
+						s.CachedHistoryTokens = common.CalculateHistoryTokens(history, orch.SystemPrompt(), orch.ToolDefinitions())
+						s.CachedHistoryLen = len(history)
+					}
+					s.CumulativeTokenCount = s.CachedHistoryTokens + newContentTokens
+				}
 			}
 
 			// Throttle viewport updates to ~33 FPS during streaming

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -60,7 +60,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	forwardToInput := true
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
-		case "y", "Y", "n", "N", "s", "S", "p", "P", "g", "G", "a", "A":
+		case "y", "Y", "n", "N", "s", "S", "p", "P", "g", "G":
 			if stateBefore == StateConfirmTool {
 				forwardToInput = false
 			}
@@ -196,7 +196,7 @@ func (m Model) updateChat(msg tea.Msg) (Model, tea.Cmd) {
 				return m, nil
 			}
 
-		case "s", "S", "p", "P", "g", "G", "a", "A":
+		case "s", "S", "p", "P", "g", "G":
 			if focusedState.State == StateConfirmTool && focusedState.PendingConfirm != nil {
 				focusedState.PendingConfirm.ResultCh <- msg.String()
 				focusedState.PendingConfirm = nil

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -60,7 +60,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	forwardToInput := true
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
-		case "y", "Y", "n", "N", "a", "A":
+		case "y", "Y", "n", "N", "s", "S", "p", "P", "g", "G", "a", "A":
 			if stateBefore == StateConfirmTool {
 				forwardToInput = false
 			}
@@ -196,7 +196,7 @@ func (m Model) updateChat(msg tea.Msg) (Model, tea.Cmd) {
 				return m, nil
 			}
 
-		case "a", "A":
+		case "s", "S", "p", "P", "g", "G", "a", "A":
 			if focusedState.State == StateConfirmTool && focusedState.PendingConfirm != nil {
 				focusedState.PendingConfirm.ResultCh <- msg.String()
 				focusedState.PendingConfirm = nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -76,7 +76,7 @@ func (m *Model) statusBarView() string {
 		modeStr = " STREAMING "
 	case StateConfirmTool:
 		modeStr = " CONFIRM "
-		statusText = "Authorize Tool Execution (y/n/a/A)"
+		statusText = "Authorize Tool Execution (y/s/p/n)"
 	}
 
 	// Check if any other agent is waiting for confirmation
@@ -311,7 +311,7 @@ func (m *Model) updateViewport() {
 		if runtime.GOOS == "windows" && displayName == "bash" {
 			displayName = "PowerShell"
 		}
-		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[ y ]** to Approve  |  **[ n ]** to Deny  |  **[ a ]** to Always Allow (Local)  |  **[ A ]** to Always Allow (Global)", displayName, tc.Function.Arguments)
+		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[ y ]** Once  |  **[ s ]** Allow Session  |  **[ p ]** Allow Project  |  **[ n ]** Deny", displayName, tc.Function.Arguments)
 		md, _ := m.Renderer.Render(prompt)
 		blocks = append(blocks, aiMsgStyle.Width(msgWidth+1).Border(lipgloss.DoubleBorder()).BorderForeground(lipgloss.Color("#FFD700")).Render(md))
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -311,7 +311,7 @@ func (m *Model) updateViewport() {
 		if runtime.GOOS == "windows" && displayName == "bash" {
 			displayName = "PowerShell"
 		}
-		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[y]** Allow once | **[s]** Allow session | **[p]** Allow project | **[g]** Allow global | **[n]** Deny", displayName, tc.Function.Arguments)
+		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[y]** Allow once | **[s]** Always: session | **[p]** Always: project | **[g]** Always: global | **[n]** Deny", displayName, tc.Function.Arguments)
 		md, _ := m.Renderer.Render(prompt)
 		blocks = append(blocks, aiMsgStyle.Width(msgWidth+1).Border(lipgloss.DoubleBorder()).BorderForeground(lipgloss.Color("#FFD700")).Render(md))
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -76,7 +76,7 @@ func (m *Model) statusBarView() string {
 		modeStr = " STREAMING "
 	case StateConfirmTool:
 		modeStr = " CONFIRM "
-		statusText = "Authorize Tool Execution (y/s/p/n)"
+		statusText = "Authorize Tool Execution (y/s/p/g/n)"
 	}
 
 	// Check if any other agent is waiting for confirmation
@@ -311,7 +311,7 @@ func (m *Model) updateViewport() {
 		if runtime.GOOS == "windows" && displayName == "bash" {
 			displayName = "PowerShell"
 		}
-		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[ y ]** Once  |  **[ s ]** Allow Session  |  **[ p ]** Allow Project  |  **[ n ]** Deny", displayName, tc.Function.Arguments)
+		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[ y ]** Once  |  **[ s ]** Allow Session  |  **[ p ]** Allow Project  |  **[ g ]** Allow Global  |  **[ n ]** Deny", displayName, tc.Function.Arguments)
 		md, _ := m.Renderer.Render(prompt)
 		blocks = append(blocks, aiMsgStyle.Width(msgWidth+1).Border(lipgloss.DoubleBorder()).BorderForeground(lipgloss.Color("#FFD700")).Render(md))
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -311,7 +311,7 @@ func (m *Model) updateViewport() {
 		if runtime.GOOS == "windows" && displayName == "bash" {
 			displayName = "PowerShell"
 		}
-		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[y]** Once | **[s]** Session | **[p]** Project | **[g]** Global | **[n]** Deny", displayName, tc.Function.Arguments)
+		prompt := fmt.Sprintf("The agent wants to execute a **%s** command.\n\n```json\n%s\n```\n\n> Press **[y]** Allow once | **[s]** Allow session | **[p]** Allow project | **[g]** Allow global | **[n]** Deny", displayName, tc.Function.Arguments)
 		md, _ := m.Renderer.Render(prompt)
 		blocks = append(blocks, aiMsgStyle.Width(msgWidth+1).Border(lipgloss.DoubleBorder()).BorderForeground(lipgloss.Color("#FFD700")).Render(md))
 	}


### PR DESCRIPTION
## Summary
Follow-up PR that introduces scoped approval decisions and automatic decay/revalidation to reduce prompt fatigue while preserving human-in-the-loop controls.

## What this adds
- Scoped confirmation choices:
  - `y` = allow once
  - `s` = allow session
  - `p` = allow project
  - `n` = deny
- Session-scoped approvals are kept in-memory and expire automatically.
- Project/global approvals are persisted with metadata and require re-validation after:
  - TTL expiry
  - app version change
- Backward-compatible loading for existing allow-list files.

## Why
This reduces repetitive prompts for clearly safe repeat actions without creating permanent trust that can silently drift over time.

## Key changes
- `internal/tool/permissions.go`
  - adds session approval storage + cleanup
  - adds TTL/version-aware metadata format for persisted approvals
  - keeps backward compatibility with old allow-list format
- `internal/tool/permissions_test.go`
  - tests session expiry
  - tests version/expiry filtering
  - tests metadata persistence/load
- TUI updates for new confirmation scope options:
  - `internal/tui/interactions.go`
  - `internal/tui/update.go`
  - `internal/tui/view.go`

## Validation
- `go test ./...` passed locally before this PR split.

## Target
- Head: `giveen/feat/approval-scopes-followup`
- Base: `mlhher/feat/ast_parser`

[X]By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository. (To check the box, put an x between the brackets like this: [x])