### PR TITLE
AST-backed Windows PowerShell command analysis

### DIFF
--- a/internal/tool/ast/feature_flag.go
+++ b/internal/tool/ast/feature_flag.go
@@ -1,0 +1,31 @@
+package ast
+
+import "os"
+
+// Feature-flag environment variables for the AST rollout.
+// These are read at call-time so they can be toggled without restarting the
+// process (useful for integration tests and gradual rollout).
+const (
+	// EnvASTShadow enables shadow mode: the AST pipeline runs alongside the
+	// legacy analyzer and logs decision deltas but does NOT change behavior.
+	EnvASTShadow = "LATE_AST_SHADOW"
+
+	// EnvASTEnforcement promotes the AST pipeline to the authoritative path.
+	// When set, the legacy analyzer is bypassed entirely. This implies shadow
+	// mode as well (no need to set both).
+	EnvASTEnforcement = "LATE_AST_ENFORCEMENT"
+)
+
+// FeatureASTShadow reports whether AST shadow mode is enabled.
+func FeatureASTShadow() bool {
+	v := os.Getenv(EnvASTShadow)
+	return v == "1" || v == "true" || v == "on"
+}
+
+// FeatureASTEnforcement reports whether AST enforcement (Phase 5) is active.
+// When true, the AST policy path is authoritative and the legacy analyzer is
+// not consulted.
+func FeatureASTEnforcement() bool {
+	v := os.Getenv(EnvASTEnforcement)
+	return v == "1" || v == "true" || v == "on"
+}

--- a/internal/tool/ast/helpers.go
+++ b/internal/tool/ast/helpers.go
@@ -1,0 +1,51 @@
+package ast
+
+// addRiskFlag adds rc to ir.RiskFlags if not already present (idempotent).
+func addRiskFlag(ir *ParsedIR, seen map[ReasonCode]bool, rc ReasonCode) {
+	if !seen[rc] {
+		seen[rc] = true
+		ir.RiskFlags = append(ir.RiskFlags, rc)
+	}
+}
+
+// addStringUnique adds s to *slice if not already tracked in seen.
+func addStringUnique(slice *[]string, seen map[string]bool, s string) {
+	if !seen[s] {
+		seen[s] = true
+		*slice = append(*slice, s)
+	}
+}
+
+// appendUniqueRC returns a new slice with rc appended only if absent.
+func appendUniqueRC(sl []ReasonCode, rc ReasonCode) []ReasonCode {
+	for _, v := range sl {
+		if v == rc {
+			return sl
+		}
+	}
+	return append(sl, rc)
+}
+
+// hasRisk reports whether rc appears in ir.RiskFlags.
+func hasRisk(ir ParsedIR, rc ReasonCode) bool {
+	for _, r := range ir.RiskFlags {
+		if r == rc {
+			return true
+		}
+	}
+	return false
+}
+
+// emptyIR returns a correctly initialised ParsedIR with all slices non-nil.
+func emptyIR(platform Platform) ParsedIR {
+	return ParsedIR{
+		Version:     IRVersion,
+		Platform:    platform,
+		Commands:    []string{},
+		Operators:   []string{},
+		Redirects:   []string{},
+		Expansions:  []string{},
+		RiskFlags:   []ReasonCode{},
+		ParseErrors: []string{},
+	}
+}

--- a/internal/tool/ast/helpers.go
+++ b/internal/tool/ast/helpers.go
@@ -36,6 +36,16 @@ func hasRisk(ir ParsedIR, rc ReasonCode) bool {
 	return false
 }
 
+// HasRiskOnly reports whether the ONLY risk flag in ir is rc.
+// Exported so ast_bridge.go (in the tool package) can call it without
+// re-importing the full policy engine.
+func HasRiskOnly(ir ParsedIR, rc ReasonCode) bool {
+	if len(ir.RiskFlags) != 1 {
+		return false
+	}
+	return ir.RiskFlags[0] == rc
+}
+
 // emptyIR returns a correctly initialised ParsedIR with all slices non-nil.
 func emptyIR(platform Platform) ParsedIR {
 	return ParsedIR{

--- a/internal/tool/ast/helpers.go
+++ b/internal/tool/ast/helpers.go
@@ -57,5 +57,6 @@ func emptyIR(platform Platform) ParsedIR {
 		Expansions:  []string{},
 		RiskFlags:   []ReasonCode{},
 		ParseErrors: []string{},
+		CommandArgs: map[string][]string{},
 	}
 }

--- a/internal/tool/ast/ir.go
+++ b/internal/tool/ast/ir.go
@@ -57,12 +57,9 @@ const (
 	ReasonSyntaxError ReasonCode = "syntax_error"
 
 	// ReasonNewPath indicates the command creates a new path inside an allowed
-	// root. Used as an auto-approval carveout signal.
+	// root. The policy engine treats this as NeedsConfirmation; callers with
+	// cwd context may downgrade to auto-approve when the target is within scope.
 	ReasonNewPath ReasonCode = "new_path"
-
-	// ReasonAllowlisted indicates the command matched an explicit allow-list
-	// entry and was auto-approved.
-	ReasonAllowlisted ReasonCode = "allowlisted"
 )
 
 // ParsedIR is the compact, JSON-safe intermediate representation emitted by

--- a/internal/tool/ast/ir.go
+++ b/internal/tool/ast/ir.go
@@ -1,0 +1,145 @@
+// Package ast provides a platform-neutral parser interface, a shared parsed
+// intermediate representation (ParsedIR), and a policy engine that operates
+// exclusively on the compact IR. It is the foundation for AST-backed command
+// analysis across Unix and Windows shells.
+package ast
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// IRVersion is the schema version for ParsedIR. All adapters MUST set this
+// field to IRVersion when emitting a ParsedIR. The policy engine and consumers
+// MUST reject any payload whose version does not match.
+const IRVersion = "1"
+
+// Platform identifies the shell environment a ParsedIR was produced for.
+type Platform string
+
+const (
+	PlatformUnix    Platform = "unix"
+	PlatformWindows Platform = "windows"
+)
+
+// ReasonCode is a normalized, deterministic policy signal emitted by adapters
+// and consumed by the policy engine. Reason codes MUST be stable across releases;
+// add new codes rather than renaming existing ones.
+type ReasonCode string
+
+const (
+	// ReasonOperator indicates a shell operator (|, &&, ||, ;, control-flow
+	// keyword) was detected. Pipelines between safe commands may override this.
+	ReasonOperator ReasonCode = "operator"
+
+	// ReasonRedirect indicates an output redirection to a non-safe target was
+	// detected (e.g. '>' to a real file rather than /dev/null).
+	ReasonRedirect ReasonCode = "redirect"
+
+	// ReasonExpansion indicates a variable/parameter expansion was detected
+	// (e.g. $VAR, ${VAR}, $(...), $(( )) on the Unix side; $var on Windows).
+	ReasonExpansion ReasonCode = "expansion"
+
+	// ReasonSubshell indicates a subshell, command substitution, or process
+	// substitution was detected.
+	ReasonSubshell ReasonCode = "subshell"
+
+	// ReasonInvokeExpr indicates a dynamic evaluation construct that can hide
+	// execution intent was detected (e.g. Invoke-Expression / iex on Windows).
+	ReasonInvokeExpr ReasonCode = "invoke_expression"
+
+	// ReasonCd indicates a 'cd' command was detected. The policy engine blocks
+	// this and directs callers to use the cwd parameter instead.
+	ReasonCd ReasonCode = "cd"
+
+	// ReasonSyntaxError indicates the command could not be fully parsed. The
+	// policy engine fails closed when this flag is present.
+	ReasonSyntaxError ReasonCode = "syntax_error"
+
+	// ReasonNewPath indicates the command creates a new path inside an allowed
+	// root. Used as an auto-approval carveout signal.
+	ReasonNewPath ReasonCode = "new_path"
+
+	// ReasonAllowlisted indicates the command matched an explicit allow-list
+	// entry and was auto-approved.
+	ReasonAllowlisted ReasonCode = "allowlisted"
+)
+
+// ParsedIR is the compact, JSON-safe intermediate representation emitted by
+// all platform adapters. It MUST NOT contain raw AST nodes—only normalized
+// signals suitable for deterministic, platform-neutral policy decisions.
+//
+// All slice fields are de-duplicated and may be empty but never nil when
+// produced by an adapter.
+type ParsedIR struct {
+	// Version MUST equal IRVersion; consumers MUST reject non-matching versions.
+	Version string `json:"version"`
+
+	// Platform identifies which adapter produced this IR.
+	Platform Platform `json:"platform"`
+
+	// Commands holds the base command/cmdlet names found in the input
+	// (e.g. ["ls", "grep"], ["Get-ChildItem"]). Values are lower-cased
+	// by the Windows adapter; Unix preserves original casing.
+	Commands []string `json:"commands"`
+
+	// Operators holds the shell operators detected (e.g. ["|", "&&", ";"]).
+	Operators []string `json:"operators"`
+
+	// Redirects holds a short descriptor for each redirection found
+	// (e.g. [">", ">>"] on Unix, ["FileRedirection"] on Windows).
+	Redirects []string `json:"redirects"`
+
+	// Expansions holds the expansion types detected
+	// (e.g. ["var", "subshell", "arith", "proc_subst"]).
+	Expansions []string `json:"expansions"`
+
+	// RiskFlags is the ordered set of normalized policy signals. The policy
+	// engine makes decisions based primarily on this field.
+	RiskFlags []ReasonCode `json:"risk_flags"`
+
+	// ParseErrors holds human-readable diagnostics from the parser. A
+	// non-empty slice indicates the input was syntactically invalid or
+	// ambiguous; callers should treat this as fail-closed.
+	ParseErrors []string `json:"parse_errors"`
+}
+
+// Parser is the interface implemented by every platform adapter. Each adapter
+// maps its native AST to a ParsedIR.
+//
+// Contract:
+//   - Parse MUST always return a valid ParsedIR (Version set, Platform set).
+//   - If parsing fails, the returned ParsedIR MUST include a ReasonSyntaxError
+//     risk flag and a non-empty ParseErrors slice, AND a non-nil error.
+//   - Callers MUST treat any non-nil error as fail-closed (require confirmation).
+type Parser interface {
+	Parse(command string) (ParsedIR, error)
+}
+
+// Decision is the output of the PolicyEngine. It mirrors CommandAnalysis but
+// lives in this package to keep ast free from circular dependencies with tool.
+type Decision struct {
+	IsBlocked         bool
+	NeedsConfirmation bool
+	BlockReason       error
+	ReasonCodes       []ReasonCode
+}
+
+// MarshalIR serializes a ParsedIR to a compact JSON byte slice.
+func MarshalIR(ir ParsedIR) ([]byte, error) {
+	return json.Marshal(ir)
+}
+
+// UnmarshalIR deserializes a JSON byte slice into a ParsedIR and validates
+// that the schema version matches IRVersion. Returns an error if the JSON is
+// malformed or the version field does not match.
+func UnmarshalIR(data []byte) (ParsedIR, error) {
+	var ir ParsedIR
+	if err := json.Unmarshal(data, &ir); err != nil {
+		return ParsedIR{}, err
+	}
+	if ir.Version != IRVersion {
+		return ParsedIR{}, fmt.Errorf("ast: unsupported IR version %q (expected %q)", ir.Version, IRVersion)
+	}
+	return ir, nil
+}

--- a/internal/tool/ast/ir.go
+++ b/internal/tool/ast/ir.go
@@ -60,6 +60,12 @@ const (
 	// root. The policy engine treats this as NeedsConfirmation; callers with
 	// cwd context may downgrade to auto-approve when the target is within scope.
 	ReasonNewPath ReasonCode = "new_path"
+
+	// ReasonDestructive indicates a command that modifies or removes filesystem
+	// objects (e.g. Remove-Item, Copy-Item, Move-Item, Set-Content on Windows).
+	// These require user confirmation but are distinct from dynamic-evaluation
+	// risks (ReasonInvokeExpr).
+	ReasonDestructive ReasonCode = "destructive"
 )
 
 // ParsedIR is the compact, JSON-safe intermediate representation emitted by

--- a/internal/tool/ast/ir.go
+++ b/internal/tool/ast/ir.go
@@ -97,6 +97,18 @@ type ParsedIR struct {
 	// (e.g. ["var", "subshell", "arith", "proc_subst"]).
 	Expansions []string `json:"expansions"`
 
+	// CommandArgs maps each base command name to the flags (args starting with
+	// '-') detected in its invocation, normalized the same way the allow-list
+	// stores them (--flag=value → --flag; numeric -N → -*). The policy engine
+	// uses this to verify that no flag absent from the stored allow-list
+	// appears in the command being evaluated, preventing a previously-approved
+	// "find ." from silently allowing "find . -exec rm -rf {} \;".
+	//
+	// Keys match the entries in Commands. An absent or empty slice means no
+	// flags were found for that command (equivalent to the bare command
+	// having been approved).
+	CommandArgs map[string][]string `json:"command_args,omitempty"`
+
 	// RiskFlags is the ordered set of normalized policy signals. The policy
 	// engine makes decisions based primarily on this field.
 	RiskFlags []ReasonCode `json:"risk_flags"`

--- a/internal/tool/ast/ir_test.go
+++ b/internal/tool/ast/ir_test.go
@@ -1,0 +1,72 @@
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalUnmarshalIR_RoundTrip(t *testing.T) {
+	original := ParsedIR{
+		Version:     IRVersion,
+		Platform:    PlatformUnix,
+		Commands:    []string{"ls", "grep"},
+		Operators:   []string{"|"},
+		Redirects:   []string{},
+		Expansions:  []string{},
+		RiskFlags:   []ReasonCode{ReasonOperator},
+		ParseErrors: []string{},
+	}
+
+	data, err := MarshalIR(original)
+	if err != nil {
+		t.Fatalf("MarshalIR: %v", err)
+	}
+
+	got, err := UnmarshalIR(data)
+	if err != nil {
+		t.Fatalf("UnmarshalIR: %v", err)
+	}
+
+	if got.Version != original.Version {
+		t.Errorf("Version: got %q want %q", got.Version, original.Version)
+	}
+	if got.Platform != original.Platform {
+		t.Errorf("Platform: got %q want %q", got.Platform, original.Platform)
+	}
+	if len(got.Commands) != len(original.Commands) {
+		t.Errorf("Commands len: got %d want %d", len(got.Commands), len(original.Commands))
+	}
+}
+
+func TestUnmarshalIR_VersionMismatch(t *testing.T) {
+	bad := map[string]any{
+		"version":  "99",
+		"platform": "unix",
+	}
+	data, _ := json.Marshal(bad)
+	if _, err := UnmarshalIR(data); err == nil {
+		t.Error("expected error for version mismatch, got nil")
+	}
+}
+
+func TestUnmarshalIR_MalformedJSON(t *testing.T) {
+	if _, err := UnmarshalIR([]byte("{not valid json")); err == nil {
+		t.Error("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestEmptyIR(t *testing.T) {
+	ir := emptyIR(PlatformWindows)
+	if ir.Commands == nil {
+		t.Error("Commands must not be nil")
+	}
+	if ir.Operators == nil {
+		t.Error("Operators must not be nil")
+	}
+	if ir.RiskFlags == nil {
+		t.Error("RiskFlags must not be nil")
+	}
+	if ir.Version != IRVersion {
+		t.Errorf("Version: got %q want %q", ir.Version, IRVersion)
+	}
+}

--- a/internal/tool/ast/policy.go
+++ b/internal/tool/ast/policy.go
@@ -1,0 +1,115 @@
+package ast
+
+import "fmt"
+
+// PolicyEngine evaluates a ParsedIR against an optional allow-list and
+// produces a Decision. The engine consumes ONLY the compact IR — no raw
+// AST nodes — making decisions deterministic and platform-neutral.
+//
+// Decision semantics (mirrors CommandAnalysis in the tool package):
+//   - IsBlocked:         hard block; execution MUST be prevented.
+//   - NeedsConfirmation: soft gate; user confirmation required before execution.
+//   - BlockReason:       non-nil error message when IsBlocked is true.
+//   - ReasonCodes:       the risk flags that drove the decision.
+type PolicyEngine struct {
+	// AllowedCommands is the merged project/global/session allow-list loaded
+	// from the permissions subsystem. Keys are normalized command strings
+	// (e.g. "git log"). A nil or empty map disables allow-list overrides.
+	AllowedCommands map[string]map[string]bool
+}
+
+// Decide converts a ParsedIR into a Decision.
+//
+// Blocking rules (checked in order):
+//  1. Fail-closed: syntax errors or empty IR → NeedsConfirmation.
+//  2. cd command → IsBlocked (users must use the cwd parameter).
+//  3. Dangerous output redirect → IsBlocked.
+//  4. Dynamic invocation (Invoke-Expression / iex) → NeedsConfirmation.
+//  5. Subshell / command substitution → NeedsConfirmation.
+//  6. Variable/parameter expansion → NeedsConfirmation.
+//  7. Shell operators (&&, ||, ;, control-flow keywords) beyond a safe plain
+//     pipe between allow-listed commands → NeedsConfirmation.
+//  8. All commands in ir.Commands are allow-listed + no blocking signals
+//     → auto-approve (NeedsConfirmation = false).
+func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
+	d := Decision{ReasonCodes: ir.RiskFlags}
+
+	// 0. Schema sanity — treat mismatched versions as fail-closed.
+	if ir.Version != IRVersion {
+		d.NeedsConfirmation = true
+		return d
+	}
+
+	// 1. Syntax/parse errors → fail closed.
+	if hasRisk(ir, ReasonSyntaxError) || len(ir.ParseErrors) > 0 {
+		d.NeedsConfirmation = true
+		return d
+	}
+
+	// 2. cd → hard block.
+	if hasRisk(ir, ReasonCd) {
+		d.IsBlocked = true
+		d.NeedsConfirmation = true
+		d.BlockReason = fmt.Errorf(
+			"Do not use `cd` to change directories. Use the `cwd` parameter in the shell tool instead.")
+		return d
+	}
+
+	// 3. Unsafe output redirect → hard block.
+	if hasRisk(ir, ReasonRedirect) {
+		d.IsBlocked = true
+		d.NeedsConfirmation = true
+		d.BlockReason = fmt.Errorf(
+			"Output redirection (>) is blocked. Use `write_file` or `target_edit` to modify files.")
+		return d
+	}
+
+	// 4–6. Soft signals → NeedsConfirmation.
+	for _, soft := range []ReasonCode{ReasonInvokeExpr, ReasonSubshell, ReasonExpansion} {
+		if hasRisk(ir, soft) {
+			d.NeedsConfirmation = true
+			return d
+		}
+	}
+
+	// 7. Operator signal (&&, ||, ;, control-flow).
+	// A plain | between all-allowlisted commands is permitted; anything else
+	// requires confirmation.
+	if hasRisk(ir, ReasonOperator) {
+		if !p.allCommandsAllowlisted(ir.Commands) {
+			d.NeedsConfirmation = true
+			return d
+		}
+		// Pure pipe between allow-listed commands — fall through to auto-approve.
+	}
+
+	// 8. Auto-approve carveout: new-path creation.
+	if hasRisk(ir, ReasonNewPath) {
+		return d // NeedsConfirmation=false, IsBlocked=false
+	}
+
+	// 9. Allow-list check: if every command is explicitly allow-listed, approve.
+	if len(ir.Commands) > 0 && p.allCommandsAllowlisted(ir.Commands) {
+		return d
+	}
+
+	// Default: unknown command combination → require confirmation.
+	if len(ir.Commands) > 0 {
+		d.NeedsConfirmation = true
+	}
+	return d
+}
+
+// allCommandsAllowlisted returns true when every command string in cmds has an
+// entry in p.AllowedCommands. An empty allow-list always returns false.
+func (p *PolicyEngine) allCommandsAllowlisted(cmds []string) bool {
+	if len(p.AllowedCommands) == 0 || len(cmds) == 0 {
+		return false
+	}
+	for _, cmd := range cmds {
+		if _, ok := p.AllowedCommands[cmd]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tool/ast/policy.go
+++ b/internal/tool/ast/policy.go
@@ -83,12 +83,7 @@ func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 		// Pure pipe between allow-listed commands — fall through to auto-approve.
 	}
 
-	// 8. Auto-approve carveout: new-path creation.
-	if hasRisk(ir, ReasonNewPath) {
-		return d // NeedsConfirmation=false, IsBlocked=false
-	}
-
-	// 9. Allow-list check: if every command is explicitly allow-listed, approve.
+	// 8. Allow-list check: if every command is explicitly allow-listed, approve.
 	if len(ir.Commands) > 0 && p.allCommandsAllowlisted(ir.Commands) {
 		return d
 	}

--- a/internal/tool/ast/policy.go
+++ b/internal/tool/ast/policy.go
@@ -27,9 +27,9 @@ type PolicyEngine struct {
 //  4. Dynamic invocation (Invoke-Expression / iex) → NeedsConfirmation.
 //  5. Subshell / command substitution → NeedsConfirmation.
 //  6. Variable/parameter expansion → NeedsConfirmation.
-//  7. Shell operators (&&, ||, ;, control-flow keywords) beyond a safe plain
-//     pipe between allow-listed commands → NeedsConfirmation.
-//  8. All commands in ir.Commands are allow-listed + no blocking signals
+//  7. Destructive filesystem operation (Remove-Item, Copy-Item, etc.) → NeedsConfirmation.
+//  8. Shell operators (&&, ||, ;, |) with any non-allow-listed command → NeedsConfirmation.
+//  9. All commands in ir.Commands are allow-listed + no blocking signals
 //     → auto-approve (NeedsConfirmation = false).
 func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 	d := Decision{ReasonCodes: ir.RiskFlags}
@@ -64,26 +64,26 @@ func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 		return d
 	}
 
-	// 4–6. Soft signals → NeedsConfirmation.
-	for _, soft := range []ReasonCode{ReasonInvokeExpr, ReasonSubshell, ReasonExpansion} {
+	// 4–7. Soft signals → NeedsConfirmation.
+	for _, soft := range []ReasonCode{ReasonInvokeExpr, ReasonSubshell, ReasonExpansion, ReasonDestructive} {
 		if hasRisk(ir, soft) {
 			d.NeedsConfirmation = true
 			return d
 		}
 	}
 
-	// 7. Operator signal (&&, ||, ;, control-flow).
-	// A plain | between all-allowlisted commands is permitted; anything else
-	// requires confirmation.
+	// 8. Operator signal (&&, ||, ;, |).
+	// Any compound/pipe where all commands are allow-listed is permitted;
+	// otherwise require confirmation.
 	if hasRisk(ir, ReasonOperator) {
 		if !p.allCommandsAllowlisted(ir.Commands) {
 			d.NeedsConfirmation = true
 			return d
 		}
-		// Pure pipe between allow-listed commands — fall through to auto-approve.
+		// All commands allowlisted — fall through to auto-approve.
 	}
 
-	// 8. Allow-list check: if every command is explicitly allow-listed, approve.
+	// 9. Allow-list check: if every command is explicitly allow-listed, approve.
 	if len(ir.Commands) > 0 && p.allCommandsAllowlisted(ir.Commands) {
 		return d
 	}

--- a/internal/tool/ast/policy.go
+++ b/internal/tool/ast/policy.go
@@ -79,7 +79,7 @@ func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 	// Any compound/pipe where all commands are allow-listed is permitted;
 	// otherwise require confirmation.
 	if hasRisk(ir, ReasonOperator) {
-		if !p.allCommandsAllowlisted(ir.Commands) {
+		if !p.allCommandsAllowlisted(ir) {
 			d.NeedsConfirmation = true
 			return d
 		}
@@ -87,7 +87,7 @@ func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 	}
 
 	// 9. Allow-list check: if every command is explicitly allow-listed, approve.
-	if len(ir.Commands) > 0 && p.allCommandsAllowlisted(ir.Commands) {
+	if len(ir.Commands) > 0 && p.allCommandsAllowlisted(ir) {
 		return d
 	}
 
@@ -98,15 +98,29 @@ func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 	return d
 }
 
-// allCommandsAllowlisted returns true when every command string in cmds has an
-// entry in p.AllowedCommands. An empty allow-list always returns false.
-func (p *PolicyEngine) allCommandsAllowlisted(cmds []string) bool {
-	if len(p.AllowedCommands) == 0 || len(cmds) == 0 {
+// allCommandsAllowlisted returns true when every command in ir.Commands has an
+// entry in p.AllowedCommands AND every flag used in the invocation is present
+// in the stored allowed-flag set for that command.
+//
+// Flag validation mirrors the legacy BashAnalyzer: if a flag appears in the
+// command but was not stored when the command was originally approved, the
+// allow-list check fails and the policy engine falls through to
+// NeedsConfirmation. This prevents a previously-approved "find ." from
+// silently permitting "find . -exec rm -rf {} \;".
+func (p *PolicyEngine) allCommandsAllowlisted(ir ParsedIR) bool {
+	if len(p.AllowedCommands) == 0 || len(ir.Commands) == 0 {
 		return false
 	}
-	for _, cmd := range cmds {
-		if _, ok := p.AllowedCommands[cmd]; !ok {
+	for _, cmd := range ir.Commands {
+		allowedFlags, ok := p.AllowedCommands[cmd]
+		if !ok {
 			return false
+		}
+		// Every flag actually used must appear in the stored allow-list.
+		for _, flag := range ir.CommandArgs[cmd] {
+			if !allowedFlags[flag] {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/tool/ast/policy.go
+++ b/internal/tool/ast/policy.go
@@ -21,15 +21,18 @@ type PolicyEngine struct {
 // Decide converts a ParsedIR into a Decision.
 //
 // Blocking rules (checked in order):
-//  1. Fail-closed: syntax errors or empty IR → NeedsConfirmation.
-//  2. cd command → IsBlocked (users must use the cwd parameter).
-//  3. Dangerous output redirect → IsBlocked.
-//  4. Dynamic invocation (Invoke-Expression / iex) → NeedsConfirmation.
-//  5. Subshell / command substitution → NeedsConfirmation.
-//  6. Variable/parameter expansion → NeedsConfirmation.
-//  7. Destructive filesystem operation (Remove-Item, Copy-Item, etc.) → NeedsConfirmation.
-//  8. Shell operators (&&, ||, ;, |) with any non-allow-listed command → NeedsConfirmation.
-//  9. All commands in ir.Commands are allow-listed + no blocking signals
+//  1. Schema version mismatch → NeedsConfirmation (fail-closed).
+//  2. Syntax/parse errors → NeedsConfirmation (fail-closed).
+//     Note: an empty IR with no risk flags and no parse errors is valid and
+//     auto-approves (rule 9 below). Only explicit parse errors trigger this.
+//  3. cd command → IsBlocked (users must use the cwd parameter).
+//  4. Dangerous output redirect → IsBlocked.
+//  5. Dynamic invocation (Invoke-Expression / iex) → NeedsConfirmation.
+//  6. Subshell / command substitution → NeedsConfirmation.
+//  7. Variable/parameter expansion → NeedsConfirmation.
+//  8. Destructive filesystem operation (Remove-Item, Copy-Item, etc.) → NeedsConfirmation.
+//  9. Shell operators (&&, ||, ;, |) with any non-allow-listed command → NeedsConfirmation.
+// 10. All commands in ir.Commands are allow-listed + no blocking signals
 //     → auto-approve (NeedsConfirmation = false).
 func (p *PolicyEngine) Decide(ir ParsedIR) Decision {
 	d := Decision{ReasonCodes: ir.RiskFlags}

--- a/internal/tool/ast/policy_test.go
+++ b/internal/tool/ast/policy_test.go
@@ -1,0 +1,128 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestPolicyEngine_Decide_Blocked(t *testing.T) {
+	pe := &PolicyEngine{}
+
+	t.Run("cd blocks", func(t *testing.T) {
+		ir := emptyIR(PlatformUnix)
+		ir.RiskFlags = []ReasonCode{ReasonCd}
+		d := pe.Decide(ir)
+		if !d.IsBlocked {
+			t.Error("expected IsBlocked for ReasonCd")
+		}
+		if d.BlockReason == nil {
+			t.Error("expected non-nil BlockReason for ReasonCd")
+		}
+	})
+
+	t.Run("redirect blocks", func(t *testing.T) {
+		ir := emptyIR(PlatformUnix)
+		ir.RiskFlags = []ReasonCode{ReasonRedirect}
+		d := pe.Decide(ir)
+		if !d.IsBlocked {
+			t.Error("expected IsBlocked for ReasonRedirect")
+		}
+	})
+
+	t.Run("syntax error fail-closed", func(t *testing.T) {
+		ir := emptyIR(PlatformUnix)
+		ir.RiskFlags = []ReasonCode{ReasonSyntaxError}
+		d := pe.Decide(ir)
+		if !d.NeedsConfirmation {
+			t.Error("expected NeedsConfirmation for ReasonSyntaxError")
+		}
+		if d.IsBlocked {
+			t.Error("syntax error should not be IsBlocked, only NeedsConfirmation")
+		}
+	})
+}
+
+func TestPolicyEngine_Decide_SoftSignals(t *testing.T) {
+	pe := &PolicyEngine{}
+	for _, rc := range []ReasonCode{ReasonSubshell, ReasonExpansion, ReasonInvokeExpr} {
+		t.Run(string(rc), func(t *testing.T) {
+			ir := emptyIR(PlatformUnix)
+			ir.RiskFlags = []ReasonCode{rc}
+			d := pe.Decide(ir)
+			if !d.NeedsConfirmation {
+				t.Errorf("expected NeedsConfirmation for %v", rc)
+			}
+			if d.IsBlocked {
+				t.Errorf("expected not IsBlocked for soft signal %v", rc)
+			}
+		})
+	}
+}
+
+func TestPolicyEngine_Decide_AllowlistedAutoApprove(t *testing.T) {
+	pe := &PolicyEngine{
+		AllowedCommands: map[string]map[string]bool{
+			"ls":   {},
+			"grep": {},
+		},
+	}
+
+	ir := emptyIR(PlatformUnix)
+	ir.Commands = []string{"ls", "grep"}
+	ir.RiskFlags = []ReasonCode{ReasonOperator}
+	ir.Operators = []string{"|"}
+
+	d := pe.Decide(ir)
+	if d.NeedsConfirmation {
+		t.Error("expected auto-approve for pipe between all-allowlisted commands")
+	}
+	if d.IsBlocked {
+		t.Error("expected not blocked for allowlisted pipe")
+	}
+}
+
+func TestPolicyEngine_Decide_PartialAllowlistRequiresConfirm(t *testing.T) {
+	pe := &PolicyEngine{
+		AllowedCommands: map[string]map[string]bool{
+			"ls": {},
+		},
+	}
+
+	ir := emptyIR(PlatformUnix)
+	ir.Commands = []string{"ls", "rm"}
+	ir.RiskFlags = []ReasonCode{ReasonOperator}
+
+	d := pe.Decide(ir)
+	if !d.NeedsConfirmation {
+		t.Error("expected NeedsConfirmation: rm is not in allow-list")
+	}
+}
+
+func TestPolicyEngine_Decide_VersionMismatch(t *testing.T) {
+	pe := &PolicyEngine{}
+	ir := emptyIR(PlatformUnix)
+	ir.Version = "99"
+	d := pe.Decide(ir)
+	if !d.NeedsConfirmation {
+		t.Error("expected NeedsConfirmation for version mismatch")
+	}
+}
+
+func TestPolicyEngine_Decide_EmptyCommandsNoConfirm(t *testing.T) {
+	pe := &PolicyEngine{}
+	ir := emptyIR(PlatformUnix)
+	// No commands, no risk flags — unusual but should not confirm.
+	d := pe.Decide(ir)
+	if d.NeedsConfirmation {
+		t.Error("empty IR with no risk flags should not require confirmation")
+	}
+}
+
+func TestPolicyEngine_Decide_UnknownCommandRequiresConfirm(t *testing.T) {
+	pe := &PolicyEngine{}
+	ir := emptyIR(PlatformUnix)
+	ir.Commands = []string{"wget"}
+	d := pe.Decide(ir)
+	if !d.NeedsConfirmation {
+		t.Error("expected NeedsConfirmation for unknown command")
+	}
+}

--- a/internal/tool/ast/policy_test.go
+++ b/internal/tool/ast/policy_test.go
@@ -126,3 +126,102 @@ func TestPolicyEngine_Decide_UnknownCommandRequiresConfirm(t *testing.T) {
 		t.Error("expected NeedsConfirmation for unknown command")
 	}
 }
+
+// TestPolicyEngine_FlagEnforcement verifies that the policy engine validates
+// flags against the stored allow-list, mirroring legacy BashAnalyzer behaviour.
+// A previously-approved "find ." must NOT silently permit "find . -exec rm -rf".
+func TestPolicyEngine_FlagEnforcement(t *testing.T) {
+	t.Run("unapproved flag blocks auto-approve", func(t *testing.T) {
+		// Only "find" with no flags was stored in the allow-list.
+		pe := &PolicyEngine{
+			AllowedCommands: map[string]map[string]bool{
+				"find": {},
+			},
+		}
+		ir := emptyIR(PlatformUnix)
+		ir.Commands = []string{"find"}
+		ir.CommandArgs = map[string][]string{
+			"find": {"-exec"},
+		}
+
+		d := pe.Decide(ir)
+		if !d.NeedsConfirmation {
+			t.Error("expected NeedsConfirmation: -exec was not in stored allow-list")
+		}
+	})
+
+	t.Run("approved flag permits auto-approve", func(t *testing.T) {
+		pe := &PolicyEngine{
+			AllowedCommands: map[string]map[string]bool{
+				"find": {"-name": true, "-type": true},
+			},
+		}
+		ir := emptyIR(PlatformUnix)
+		ir.Commands = []string{"find"}
+		ir.CommandArgs = map[string][]string{
+			"find": {"-name", "-type"},
+		}
+
+		d := pe.Decide(ir)
+		if d.NeedsConfirmation {
+			t.Error("expected auto-approve: all flags are in the stored allow-list")
+		}
+	})
+
+	t.Run("no flags used auto-approves bare command", func(t *testing.T) {
+		pe := &PolicyEngine{
+			AllowedCommands: map[string]map[string]bool{
+				"find": {},
+			},
+		}
+		ir := emptyIR(PlatformUnix)
+		ir.Commands = []string{"find"}
+		// CommandArgs empty — bare "find ." with no flags.
+
+		d := pe.Decide(ir)
+		if d.NeedsConfirmation {
+			t.Error("expected auto-approve for bare allow-listed command with no flags")
+		}
+	})
+
+	t.Run("pipe: unapproved flag on one command blocks", func(t *testing.T) {
+		pe := &PolicyEngine{
+			AllowedCommands: map[string]map[string]bool{
+				"find": {},
+				"grep": {"-r": true},
+			},
+		}
+		ir := emptyIR(PlatformUnix)
+		ir.Commands = []string{"find", "grep"}
+		ir.Operators = []string{"|"}
+		ir.RiskFlags = []ReasonCode{ReasonOperator}
+		ir.CommandArgs = map[string][]string{
+			"find": {"-exec"}, // not in stored flags → must block
+			"grep": {"-r"},
+		}
+
+		d := pe.Decide(ir)
+		if !d.NeedsConfirmation {
+			t.Error("expected NeedsConfirmation: find -exec not in stored allow-list")
+		}
+	})
+
+	t.Run("unix: find -exec rm -rf parsed as unapproved flag", func(t *testing.T) {
+		// End-to-end through the Unix parser.
+		pe := &PolicyEngine{
+			AllowedCommands: map[string]map[string]bool{
+				"find": {}, // only bare find was approved
+			},
+		}
+		p := &UnixParser{}
+		ir, err := p.Parse(`find . -exec rm -rf {} \;`)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+
+		d := pe.Decide(ir)
+		if !d.NeedsConfirmation {
+			t.Error("expected NeedsConfirmation: -exec not in stored allow-list")
+		}
+	})
+}

--- a/internal/tool/ast/policy_test.go
+++ b/internal/tool/ast/policy_test.go
@@ -43,7 +43,7 @@ func TestPolicyEngine_Decide_Blocked(t *testing.T) {
 
 func TestPolicyEngine_Decide_SoftSignals(t *testing.T) {
 	pe := &PolicyEngine{}
-	for _, rc := range []ReasonCode{ReasonSubshell, ReasonExpansion, ReasonInvokeExpr} {
+	for _, rc := range []ReasonCode{ReasonSubshell, ReasonExpansion, ReasonInvokeExpr, ReasonDestructive} {
 		t.Run(string(rc), func(t *testing.T) {
 			ir := emptyIR(PlatformUnix)
 			ir.RiskFlags = []ReasonCode{rc}

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -43,22 +43,6 @@ try {
     exit 0
 }
 
-# Input sanitization: reject null bytes or absurdly long input.
-if ($command -match '\x00') {
-    $ir = New-IR
-    Add-Unique $ir.risk_flags "syntax_error"
-    $ir.parse_errors.Add("command contains null byte") | Out-Null
-    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
-    exit 0
-}
-if ($command.Length -gt 65536) {
-    $ir = New-IR
-    Add-Unique $ir.risk_flags "syntax_error"
-    $ir.parse_errors.Add("command exceeds maximum length") | Out-Null
-    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
-    exit 0
-}
-
 $ir = New-IR
 
 # --- Parse ---
@@ -158,7 +142,6 @@ foreach ($node in $allNodes) {
 
     # File redirection (> >>)
     if ($node -is [System.Management.Automation.Language.FileRedirectionAst]) {
-        $loc = $node.Location
         Add-Unique $ir.redirects "FileRedirection"
         Add-Unique $ir.risk_flags "redirect"
         continue

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -1,13 +1,16 @@
 # ps_bridge.ps1 — AST-backed command parser for the late agent.
-# Reads a raw command string from stdin, parses it with
+# Runs as a persistent process. Each iteration reads one newline-delimited JSON
+# request from stdin ({"cmd":"..."}), parses the command with
 # System.Management.Automation.Language.Parser::ParseInput, walks the
-# resulting AST and emits a compact JSON IR to stdout.
+# resulting AST, and writes one compact JSON IR line to stdout.
+# Repeats until stdin is closed (EOF), then exits.
 #
 # CONTRACT:
 #   - This script NEVER executes the input command.
-#   - stdout carries exactly one line of compact JSON matching ParsedIR schema.
+#   - Each response is exactly one line of compact JSON matching ParsedIR schema.
 #   - On any error the script still emits valid JSON with risk_flag "syntax_error".
 #   - Exit code is always 0 (errors are encoded in the JSON payload).
+#   - Each response line is flushed immediately so the Go caller can read it.
 
 param()
 
@@ -30,42 +33,6 @@ function New-IR {
 function Add-Unique {
     param([System.Collections.Generic.List[string]]$List, [string]$Value)
     if (-not $List.Contains($Value)) { $List.Add($Value) | Out-Null }
-}
-
-# Read command from stdin. Timeout is enforced by the Go caller (context).
-try {
-    $command = [Console]::In.ReadToEnd()
-} catch {
-    $ir = New-IR
-    Add-Unique $ir.risk_flags "syntax_error"
-    $ir.parse_errors.Add("failed to read stdin: $_") | Out-Null
-    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
-    exit 0
-}
-
-$ir = New-IR
-
-# --- Parse ---
-$tokens = $null
-try {
-    $tokenArr = [System.Management.Automation.Language.Token[]]@()
-    $errorArr = [System.Management.Automation.Language.ParseError[]]@()
-    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-        $command, [ref]$tokenArr, [ref]$errorArr
-    )
-    $tokens      = $tokenArr
-    $parseErrors = $errorArr
-} catch {
-    Add-Unique $ir.risk_flags "syntax_error"
-    $ir.parse_errors.Add($_.ToString()) | Out-Null
-    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
-    exit 0
-}
-
-# Record parser diagnostics (soft errors — PS parser is lenient).
-foreach ($e in $parseErrors) {
-    $ir.parse_errors.Add($e.Message) | Out-Null
-    Add-Unique $ir.risk_flags "syntax_error"
 }
 
 # --- Risky cmdlet names (lower-case) ---
@@ -96,124 +63,187 @@ $cdCmdlets = @(
 # Path-creation cmdlets (used for the new-path carveout signal).
 $newPathCmdlets = @('mkdir', 'md', 'new-item', 'ni')
 
-# --- Walk every AST node ---
-$allNodes = $ast.FindAll({ $true }, $true)
-foreach ($node in $allNodes) {
-    # Commands
-    if ($node -is [System.Management.Automation.Language.CommandAst]) {
-        $elems = $node.CommandElements
-        if ($elems -and $elems.Count -gt 0) {
-            $cmdName = $elems[0].ToString().Trim().ToLower()
-            if ($cmdName -ne '') {
-                Add-Unique $ir.commands $cmdName
-                if ($riskyCmdlets -contains $cmdName) {
-                    Add-Unique $ir.risk_flags "invoke_expression"
-                }
-                if ($cdCmdlets -contains $cmdName) {
-                    Add-Unique $ir.risk_flags "cd"
-                }
-                if ($newPathCmdlets -contains $cmdName) {
-                    Add-Unique $ir.risk_flags "new_path"
+# Invoke-Parse parses one command string and returns an IR hashtable.
+# Never throws — all errors are encoded inside the returned IR.
+function Invoke-Parse {
+    param([string]$command)
+
+    $ir = New-IR
+
+    # --- Parse ---
+    $tokens = $null
+    try {
+        $tokenArr = [System.Management.Automation.Language.Token[]]@()
+        $errorArr = [System.Management.Automation.Language.ParseError[]]@()
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            $command, [ref]$tokenArr, [ref]$errorArr
+        )
+        $tokens      = $tokenArr
+        $parseErrors = $errorArr
+    } catch {
+        Add-Unique $ir.risk_flags "syntax_error"
+        $ir.parse_errors.Add($_.ToString()) | Out-Null
+        return $ir
+    }
+
+    # Record parser diagnostics (soft errors — PS parser is lenient).
+    foreach ($e in $parseErrors) {
+        $ir.parse_errors.Add($e.Message) | Out-Null
+        Add-Unique $ir.risk_flags "syntax_error"
+    }
+
+    # --- Walk every AST node ---
+    $allNodes = $ast.FindAll({ $true }, $true)
+    foreach ($node in $allNodes) {
+        # Commands
+        if ($node -is [System.Management.Automation.Language.CommandAst]) {
+            $elems = $node.CommandElements
+            if ($elems -and $elems.Count -gt 0) {
+                $cmdName = $elems[0].ToString().Trim().ToLower()
+                if ($cmdName -ne '') {
+                    Add-Unique $ir.commands $cmdName
+                    if ($riskyCmdlets -contains $cmdName) {
+                        Add-Unique $ir.risk_flags "invoke_expression"
+                    }
+                    if ($cdCmdlets -contains $cmdName) {
+                        Add-Unique $ir.risk_flags "cd"
+                    }
+                    if ($newPathCmdlets -contains $cmdName) {
+                        Add-Unique $ir.risk_flags "new_path"
+                    }
                 }
             }
+            continue
         }
-        continue
+
+        # Pipeline: | operator
+        if ($node -is [System.Management.Automation.Language.PipelineAst]) {
+            if ($node.PipelineElements.Count -gt 1) {
+                Add-Unique $ir.operators "|"
+                Add-Unique $ir.risk_flags "operator"
+            }
+            continue
+        }
+
+        # && and || via PipelineChain (PS7+). Guard with -is check so older PS
+        # versions skip gracefully (the type simply won't exist).
+        if ($node.GetType().Name -eq 'PipelineChainAst') {
+            try {
+                $op = $node.Operator.ToString()
+                Add-Unique $ir.operators $op
+                Add-Unique $ir.risk_flags "operator"
+            } catch {}
+            continue
+        }
+
+        # File redirection (> >>)
+        if ($node -is [System.Management.Automation.Language.FileRedirectionAst]) {
+            Add-Unique $ir.redirects "FileRedirection"
+            Add-Unique $ir.risk_flags "redirect"
+            continue
+        }
+
+        # Merging redirection (2>&1 etc.) — not inherently risky, just record it.
+        if ($node -is [System.Management.Automation.Language.MergingRedirectionAst]) {
+            Add-Unique $ir.redirects "MergingRedirection"
+            continue
+        }
+
+        # $(...) sub-expression
+        if ($node -is [System.Management.Automation.Language.SubExpressionAst]) {
+            Add-Unique $ir.expansions "subshell"
+            Add-Unique $ir.risk_flags "subshell"
+            continue
+        }
+
+        # Variable: $var — only count top-level variable references, not those
+        # that are children of SubExpressionAst (already counted as subshell).
+        if ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
+            Add-Unique $ir.expansions "var"
+            Add-Unique $ir.risk_flags "expansion"
+            continue
+        }
+
+        # Script-block expression: { ... }
+        if ($node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+            Add-Unique $ir.expansions "script_block"
+            Add-Unique $ir.risk_flags "subshell"
+            continue
+        }
     }
 
-    # Pipeline: | operator
-    if ($node -is [System.Management.Automation.Language.PipelineAst]) {
-        if ($node.PipelineElements.Count -gt 1) {
-            Add-Unique $ir.operators "|"
+    # Detect ';' statement separator from top-level statement count.
+    try {
+        $endBlock = $ast.EndBlock
+        if ($endBlock -and $endBlock.Statements -and $endBlock.Statements.Count -gt 1) {
+            Add-Unique $ir.operators ";"
             Add-Unique $ir.risk_flags "operator"
         }
-        continue
+    } catch {}
+
+    # Scan tokens for -EncodedCommand / -enc flags and &&/|| (PS5.1 fallback
+    # since PipelineChainAst only exists in PS7+).
+    foreach ($tok in $tokens) {
+        $tv = $tok.Text.ToLower()
+        switch ($tv) {
+            '-encodedcommand' { Add-Unique $ir.risk_flags "invoke_expression" }
+            '-enc'            { Add-Unique $ir.risk_flags "invoke_expression" }
+            '-en'             { Add-Unique $ir.risk_flags "invoke_expression" }
+            '&&' {
+                Add-Unique $ir.operators "&&"
+                Add-Unique $ir.risk_flags "operator"
+            }
+            '||' {
+                Add-Unique $ir.operators "||"
+                Add-Unique $ir.risk_flags "operator"
+            }
+        }
     }
 
-    # && and || via PipelineChain (PS7+). Guard with -is check so older PS
-    # versions skip gracefully (the type simply won't exist).
-    if ($node.GetType().Name -eq 'PipelineChainAst') {
-        try {
-            $op = $node.Operator.ToString()
-            Add-Unique $ir.operators $op
-            Add-Unique $ir.risk_flags "operator"
-        } catch {}
-        continue
-    }
-
-    # File redirection (> >>)
-    if ($node -is [System.Management.Automation.Language.FileRedirectionAst]) {
-        Add-Unique $ir.redirects "FileRedirection"
-        Add-Unique $ir.risk_flags "redirect"
-        continue
-    }
-
-    # Merging redirection (2>&1 etc.) — not inherently risky, just record it.
-    if ($node -is [System.Management.Automation.Language.MergingRedirectionAst]) {
-        Add-Unique $ir.redirects "MergingRedirection"
-        continue
-    }
-
-    # $(...) sub-expression
-    if ($node -is [System.Management.Automation.Language.SubExpressionAst]) {
-        Add-Unique $ir.expansions "subshell"
-        Add-Unique $ir.risk_flags "subshell"
-        continue
-    }
-
-    # Variable: $var — only count top-level variable references, not those
-    # that are children of SubExpressionAst (already counted as subshell).
-    if ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
-        Add-Unique $ir.expansions "var"
-        Add-Unique $ir.risk_flags "expansion"
-        continue
-    }
-
-    # Script-block expression: { ... }
-    if ($node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
-        Add-Unique $ir.expansions "script_block"
-        Add-Unique $ir.risk_flags "subshell"
-        continue
-    }
+    return $ir
 }
 
-# Detect ';' statement separator from top-level statement count.
-try {
-    $endBlock = $ast.EndBlock
-    if ($endBlock -and $endBlock.Statements -and $endBlock.Statements.Count -gt 1) {
-        Add-Unique $ir.operators ";"
-        Add-Unique $ir.risk_flags "operator"
+# Emit-IR serializes an IR hashtable to a compact JSON line and flushes stdout
+# immediately so the Go reader is not left waiting for a buffer to fill.
+function Emit-IR {
+    param($ir)
+    $out = [ordered]@{
+        version      = $ir.version
+        platform     = $ir.platform
+        commands     = @($ir.commands)
+        operators    = @($ir.operators)
+        redirects    = @($ir.redirects)
+        expansions   = @($ir.expansions)
+        risk_flags   = @($ir.risk_flags)
+        parse_errors = @($ir.parse_errors)
     }
-} catch {}
-
-# Scan tokens for -EncodedCommand / -enc flags and &&/|| (PS5.1 fallback
-# since PipelineChainAst only exists in PS7+).
-foreach ($tok in $tokens) {
-    $tv = $tok.Text.ToLower()
-    switch ($tv) {
-        '-encodedcommand' { Add-Unique $ir.risk_flags "invoke_expression" }
-        '-enc'            { Add-Unique $ir.risk_flags "invoke_expression" }
-        '-en'             { Add-Unique $ir.risk_flags "invoke_expression" }
-        '&&' {
-            Add-Unique $ir.operators "&&"
-            Add-Unique $ir.risk_flags "operator"
-        }
-        '||' {
-            Add-Unique $ir.operators "||"
-            Add-Unique $ir.risk_flags "operator"
-        }
-    }
+    [Console]::Out.WriteLine(($out | ConvertTo-Json -Compress -Depth 3))
+    [Console]::Out.Flush()
 }
 
-# Serialize — convert List<string> fields to plain arrays for ConvertTo-Json.
-$out = [ordered]@{
-    version      = $ir.version
-    platform     = $ir.platform
-    commands     = @($ir.commands)
-    operators    = @($ir.operators)
-    redirects    = @($ir.redirects)
-    expansions   = @($ir.expansions)
-    risk_flags   = @($ir.risk_flags)
-    parse_errors = @($ir.parse_errors)
-}
+# --- Main persistent loop ---
+# Each iteration: read one JSON request line {"cmd":"..."}, parse, emit one
+# JSON response line. Exits when stdin reaches EOF (Go closes the pipe).
+while ($true) {
+    $line = $null
+    try {
+        $line = [Console]::In.ReadLine()
+    } catch {
+        break
+    }
+    if ($null -eq $line) { break }
+    $line = $line.Trim()
+    if ($line -eq '') { continue }
 
-Write-Output ($out | ConvertTo-Json -Compress -Depth 3)
+    $ir = $null
+    try {
+        $req = ConvertFrom-Json $line
+        $ir = Invoke-Parse $req.cmd
+    } catch {
+        $ir = New-IR
+        Add-Unique $ir.risk_flags "syntax_error"
+        $ir.parse_errors.Add("request error: $_") | Out-Null
+    }
+
+    Emit-IR $ir
+}

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -1,0 +1,203 @@
+# ps_bridge.ps1 — AST-backed command parser for the late agent.
+# Reads a raw command string from stdin, parses it with
+# System.Management.Automation.Language.Parser::ParseInput, walks the
+# resulting AST and emits a compact JSON IR to stdout.
+#
+# CONTRACT:
+#   - This script NEVER executes the input command.
+#   - stdout carries exactly one line of compact JSON matching ParsedIR schema.
+#   - On any error the script still emits valid JSON with risk_flag "syntax_error".
+#   - Exit code is always 0 (errors are encoded in the JSON payload).
+
+param()
+
+Set-StrictMode -Off
+$ErrorActionPreference = 'Stop'
+
+function New-IR {
+    return @{
+        version      = "1"
+        platform     = "windows"
+        commands     = [System.Collections.Generic.List[string]]::new()
+        operators    = [System.Collections.Generic.List[string]]::new()
+        redirects    = [System.Collections.Generic.List[string]]::new()
+        expansions   = [System.Collections.Generic.List[string]]::new()
+        risk_flags   = [System.Collections.Generic.List[string]]::new()
+        parse_errors = [System.Collections.Generic.List[string]]::new()
+    }
+}
+
+function Add-Unique {
+    param([System.Collections.Generic.List[string]]$List, [string]$Value)
+    if (-not $List.Contains($Value)) { $List.Add($Value) | Out-Null }
+}
+
+# Read command from stdin. Timeout is enforced by the Go caller (context).
+try {
+    $command = [Console]::In.ReadToEnd()
+} catch {
+    $ir = New-IR
+    Add-Unique $ir.risk_flags "syntax_error"
+    $ir.parse_errors.Add("failed to read stdin: $_") | Out-Null
+    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
+    exit 0
+}
+
+$ir = New-IR
+
+# --- Parse ---
+$parseErrors = $null
+$tokens      = $null
+try {
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $command,
+        [ref][System.Management.Automation.Language.Token[]]@(),
+        [ref][System.Management.Automation.Language.ParseError[]]@()
+    )
+    # Re-parse with proper out params to capture errors and tokens
+    $tokenArr = [System.Management.Automation.Language.Token[]]@()
+    $errorArr = [System.Management.Automation.Language.ParseError[]]@()
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $command, [ref]$tokenArr, [ref]$errorArr
+    )
+    $tokens     = $tokenArr
+    $parseErrors = $errorArr
+} catch {
+    Add-Unique $ir.risk_flags "syntax_error"
+    $ir.parse_errors.Add($_.ToString()) | Out-Null
+    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
+    exit 0
+}
+
+# Record parser diagnostics (soft errors — PS parser is lenient).
+foreach ($e in $parseErrors) {
+    $ir.parse_errors.Add($e.Message) | Out-Null
+    Add-Unique $ir.risk_flags "syntax_error"
+}
+
+# --- Risky cmdlet names (lower-case) ---
+$riskyCmdlets = @(
+    'invoke-expression', 'iex',
+    'start-process',     'saps',
+    'invoke-command',    'icm',
+    'new-object',
+    'remove-item',       'ri', 'del', 'erase', 'rd', 'rmdir', 'rm',
+    'rename-item',       'rni', 'ren',
+    'move-item',         'mi', 'move', 'mv',
+    'copy-item',         'ci', 'copy', 'cp',
+    'set-content',       'sc',
+    'add-content',       'ac',
+    'out-file',
+    'clear-content',     'clc',
+    'set-itemproperty',  'sp',
+    'set-acl'
+)
+
+# --- Walk every AST node ---
+$allNodes = $ast.FindAll({ $true }, $true)
+foreach ($node in $allNodes) {
+    # Commands
+    if ($node -is [System.Management.Automation.Language.CommandAst]) {
+        $elems = $node.CommandElements
+        if ($elems -and $elems.Count -gt 0) {
+            $cmdName = $elems[0].ToString().Trim().ToLower()
+            if ($cmdName -ne '') {
+                Add-Unique $ir.commands $cmdName
+                if ($riskyCmdlets -contains $cmdName) {
+                    Add-Unique $ir.risk_flags "invoke_expression"
+                }
+            }
+        }
+        continue
+    }
+
+    # Pipeline: | operator
+    if ($node -is [System.Management.Automation.Language.PipelineAst]) {
+        if ($node.PipelineElements.Count -gt 1) {
+            Add-Unique $ir.operators "|"
+            Add-Unique $ir.risk_flags "operator"
+        }
+        continue
+    }
+
+    # && and || via PipelineChain (PS7+). Guard with -is check so older PS
+    # versions skip gracefully (the type simply won't exist).
+    if ($node.GetType().Name -eq 'PipelineChainAst') {
+        try {
+            $op = $node.Operator.ToString()
+            Add-Unique $ir.operators $op
+            Add-Unique $ir.risk_flags "operator"
+        } catch {}
+        continue
+    }
+
+    # File redirection (> >>)
+    if ($node -is [System.Management.Automation.Language.FileRedirectionAst]) {
+        $loc = $node.Location
+        Add-Unique $ir.redirects "FileRedirection"
+        Add-Unique $ir.risk_flags "redirect"
+        continue
+    }
+
+    # Merging redirection (2>&1 etc.) — not inherently risky, just record it.
+    if ($node -is [System.Management.Automation.Language.MergingRedirectionAst]) {
+        Add-Unique $ir.redirects "MergingRedirection"
+        continue
+    }
+
+    # $(...) sub-expression
+    if ($node -is [System.Management.Automation.Language.SubExpressionAst]) {
+        Add-Unique $ir.expansions "subshell"
+        Add-Unique $ir.risk_flags "subshell"
+        continue
+    }
+
+    # Variable: $var — only count top-level variable references, not those
+    # that are children of SubExpressionAst (already counted as subshell).
+    if ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
+        Add-Unique $ir.expansions "var"
+        Add-Unique $ir.risk_flags "expansion"
+        continue
+    }
+
+    # Script-block expression: { ... }
+    if ($node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+        Add-Unique $ir.expansions "script_block"
+        Add-Unique $ir.risk_flags "subshell"
+        continue
+    }
+}
+
+# Detect ';' statement separator from top-level statement count.
+try {
+    $endBlock = $ast.EndBlock
+    if ($endBlock -and $endBlock.Statements -and $endBlock.Statements.Count -gt 1) {
+        Add-Unique $ir.operators ";"
+        Add-Unique $ir.risk_flags "operator"
+    }
+} catch {}
+
+# Scan tokens for -EncodedCommand / -enc flags and raw > / >> that the AST
+# may not surface (e.g. inside strings).
+foreach ($tok in $tokens) {
+    $tv = $tok.Text.ToLower()
+    switch ($tv) {
+        '-encodedcommand' { Add-Unique $ir.risk_flags "invoke_expression" }
+        '-enc'            { Add-Unique $ir.risk_flags "invoke_expression" }
+        '-en'             { Add-Unique $ir.risk_flags "invoke_expression" }
+    }
+}
+
+# Serialize — convert List<string> fields to plain arrays for ConvertTo-Json.
+$out = [ordered]@{
+    version      = $ir.version
+    platform     = $ir.platform
+    commands     = @($ir.commands)
+    operators    = @($ir.operators)
+    redirects    = @($ir.redirects)
+    expansions   = @($ir.expansions)
+    risk_flags   = @($ir.risk_flags)
+    parse_errors = @($ir.parse_errors)
+}
+
+Write-Output ($out | ConvertTo-Json -Compress -Depth 3)

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -35,12 +35,19 @@ function Add-Unique {
     if (-not $List.Contains($Value)) { $List.Add($Value) | Out-Null }
 }
 
-# --- Risky cmdlet names (lower-case) ---
-$riskyCmdlets = @(
+# Dynamic-evaluation cmdlets — emit "invoke_expression".
+# These can hide execution intent or run arbitrary code.
+$invokeRiskCmdlets = @(
     'invoke-expression', 'iex',
     'start-process',     'saps',
     'invoke-command',    'icm',
-    'new-object',
+    'new-object'
+)
+
+# Destructive filesystem cmdlets — emit "destructive".
+# These modify or remove files and require user confirmation, but are
+# semantically distinct from dynamic-evaluation risks.
+$destructiveCmdlets = @(
     'remove-item',       'ri', 'del', 'erase', 'rd', 'rmdir', 'rm',
     'rename-item',       'rni', 'ren',
     'move-item',         'mi', 'move', 'mv',
@@ -102,8 +109,11 @@ function Invoke-Parse {
                 $cmdName = $elems[0].ToString().Trim().ToLower()
                 if ($cmdName -ne '') {
                     Add-Unique $ir.commands $cmdName
-                    if ($riskyCmdlets -contains $cmdName) {
+                    if ($invokeRiskCmdlets -contains $cmdName) {
                         Add-Unique $ir.risk_flags "invoke_expression"
+                    }
+                    if ($destructiveCmdlets -contains $cmdName) {
+                        Add-Unique $ir.risk_flags "destructive"
                     }
                     if ($cdCmdlets -contains $cmdName) {
                         Add-Unique $ir.risk_flags "cd"

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -52,7 +52,7 @@ $destructiveCmdlets = @(
     'rename-item',       'rni', 'ren',
     'move-item',         'mi', 'move', 'mv',
     'copy-item',         'ci', 'copy', 'cp',
-    'set-content',       'sc',
+    'set-content',       'sc',        # NOTE: 'sc' also matches sc.exe (Service Control Manager); accepted false-positive.
     'add-content',       'ac',
     'out-file',
     'clear-content',     'clc',
@@ -174,12 +174,6 @@ function Invoke-Parse {
             continue
         }
 
-        # Script-block expression: { ... }
-        if ($node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
-            Add-Unique $ir.expansions "script_block"
-            Add-Unique $ir.risk_flags "subshell"
-            continue
-        }
     }
 
     # Detect ';' statement separator from top-level statement count.

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -43,24 +43,33 @@ try {
     exit 0
 }
 
+# Input sanitization: reject null bytes or absurdly long input.
+if ($command -match '\x00') {
+    $ir = New-IR
+    Add-Unique $ir.risk_flags "syntax_error"
+    $ir.parse_errors.Add("command contains null byte") | Out-Null
+    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
+    exit 0
+}
+if ($command.Length -gt 65536) {
+    $ir = New-IR
+    Add-Unique $ir.risk_flags "syntax_error"
+    $ir.parse_errors.Add("command exceeds maximum length") | Out-Null
+    Write-Output ($ir | ConvertTo-Json -Compress -Depth 3)
+    exit 0
+}
+
 $ir = New-IR
 
 # --- Parse ---
-$parseErrors = $null
-$tokens      = $null
+$tokens = $null
 try {
-    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-        $command,
-        [ref][System.Management.Automation.Language.Token[]]@(),
-        [ref][System.Management.Automation.Language.ParseError[]]@()
-    )
-    # Re-parse with proper out params to capture errors and tokens
     $tokenArr = [System.Management.Automation.Language.Token[]]@()
     $errorArr = [System.Management.Automation.Language.ParseError[]]@()
     $ast = [System.Management.Automation.Language.Parser]::ParseInput(
         $command, [ref]$tokenArr, [ref]$errorArr
     )
-    $tokens     = $tokenArr
+    $tokens      = $tokenArr
     $parseErrors = $errorArr
 } catch {
     Add-Unique $ir.risk_flags "syntax_error"
@@ -93,6 +102,16 @@ $riskyCmdlets = @(
     'set-acl'
 )
 
+# cd / Set-Location aliases — policy engine blocks these.
+$cdCmdlets = @(
+    'set-location', 'sl', 'cd', 'chdir',
+    'push-location', 'pushd',
+    'pop-location',  'popd'
+)
+
+# Path-creation cmdlets (used for the new-path carveout signal).
+$newPathCmdlets = @('mkdir', 'md', 'new-item', 'ni')
+
 # --- Walk every AST node ---
 $allNodes = $ast.FindAll({ $true }, $true)
 foreach ($node in $allNodes) {
@@ -105,6 +124,12 @@ foreach ($node in $allNodes) {
                 Add-Unique $ir.commands $cmdName
                 if ($riskyCmdlets -contains $cmdName) {
                     Add-Unique $ir.risk_flags "invoke_expression"
+                }
+                if ($cdCmdlets -contains $cmdName) {
+                    Add-Unique $ir.risk_flags "cd"
+                }
+                if ($newPathCmdlets -contains $cmdName) {
+                    Add-Unique $ir.risk_flags "new_path"
                 }
             }
         }
@@ -177,14 +202,22 @@ try {
     }
 } catch {}
 
-# Scan tokens for -EncodedCommand / -enc flags and raw > / >> that the AST
-# may not surface (e.g. inside strings).
+# Scan tokens for -EncodedCommand / -enc flags and &&/|| (PS5.1 fallback
+# since PipelineChainAst only exists in PS7+).
 foreach ($tok in $tokens) {
     $tv = $tok.Text.ToLower()
     switch ($tv) {
         '-encodedcommand' { Add-Unique $ir.risk_flags "invoke_expression" }
         '-enc'            { Add-Unique $ir.risk_flags "invoke_expression" }
         '-en'             { Add-Unique $ir.risk_flags "invoke_expression" }
+        '&&' {
+            Add-Unique $ir.operators "&&"
+            Add-Unique $ir.risk_flags "operator"
+        }
+        '||' {
+            Add-Unique $ir.operators "||"
+            Add-Unique $ir.risk_flags "operator"
+        }
     }
 }
 

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -166,11 +166,18 @@ function Invoke-Parse {
             continue
         }
 
-        # Variable: $var — only count top-level variable references, not those
-        # that are children of SubExpressionAst (already counted as subshell).
+        # Variable: $var — flag genuine dynamic expansions only.
+        # Exclude PowerShell language constants ($true, $false, $null) and the
+        # pipeline iteration variable ($_ / $PSItem): they are not user-controlled
+        # and trigger false-positive confirmations on normal filter expressions
+        # such as  Where-Object { $_.Name -eq 'foo' }.
         if ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
-            Add-Unique $ir.expansions "var"
-            Add-Unique $ir.risk_flags "expansion"
+            $varName = $node.VariablePath.UserPath.ToLower()
+            $constants = @('true', 'false', 'null', '_', 'psitem')
+            if ($constants -notcontains $varName) {
+                Add-Unique $ir.expansions "var"
+                Add-Unique $ir.risk_flags "expansion"
+            }
             continue
         }
 

--- a/internal/tool/ast/ps_bridge.ps1
+++ b/internal/tool/ast/ps_bridge.ps1
@@ -27,6 +27,7 @@ function New-IR {
         expansions   = [System.Collections.Generic.List[string]]::new()
         risk_flags   = [System.Collections.Generic.List[string]]::new()
         parse_errors = [System.Collections.Generic.List[string]]::new()
+        command_args = @{}  # hashtable: cmdName -> List[string] of flags
     }
 }
 
@@ -120,6 +121,21 @@ function Invoke-Parse {
                     }
                     if ($newPathCmdlets -contains $cmdName) {
                         Add-Unique $ir.risk_flags "new_path"
+                    }
+                    # Collect flags for policy engine allow-list matching.
+                    if (-not $ir.command_args.ContainsKey($cmdName)) {
+                        $ir.command_args[$cmdName] = [System.Collections.Generic.List[string]]::new()
+                    }
+                    for ($i = 1; $i -lt $elems.Count; $i++) {
+                        $argText = $elems[$i].ToString().Trim()
+                        if ($argText.StartsWith('-')) {
+                            # Normalize -Param:value → -Param (PowerShell colon syntax)
+                            $colonIdx = $argText.IndexOf(':')
+                            if ($colonIdx -gt 0) { $argText = $argText.Substring(0, $colonIdx) }
+                            if (-not $ir.command_args[$cmdName].Contains($argText)) {
+                                $ir.command_args[$cmdName].Add($argText) | Out-Null
+                            }
+                        }
                     }
                 }
             }
@@ -218,6 +234,11 @@ function Invoke-Parse {
 # immediately so the Go reader is not left waiting for a buffer to fill.
 function Emit-IR {
     param($ir)
+    # Convert command_args hashtable → plain hashtable of arrays for JSON.
+    $cmdArgsOut = @{}
+    foreach ($k in $ir.command_args.Keys) {
+        $cmdArgsOut[$k] = @($ir.command_args[$k])
+    }
     $out = [ordered]@{
         version      = $ir.version
         platform     = $ir.platform
@@ -227,6 +248,7 @@ function Emit-IR {
         expansions   = @($ir.expansions)
         risk_flags   = @($ir.risk_flags)
         parse_errors = @($ir.parse_errors)
+        command_args = $cmdArgsOut
     }
     [Console]::Out.WriteLine(($out | ConvertTo-Json -Compress -Depth 3))
     [Console]::Out.Flush()

--- a/internal/tool/ast/registry.go
+++ b/internal/tool/ast/registry.go
@@ -1,0 +1,26 @@
+package ast
+
+import "runtime"
+
+// NewParser returns the platform-appropriate parser adapter for the given
+// platform. Passing an explicit platform overrides runtime detection, which is
+// useful for cross-platform unit tests.
+//
+// cwd is the working-directory context passed to adapters that need path
+// resolution (currently only WindowsParser).
+func NewParser(platform Platform, cwd string) Parser {
+	switch platform {
+	case PlatformWindows:
+		return &WindowsParser{Cwd: cwd}
+	default:
+		return &UnixParser{}
+	}
+}
+
+// CurrentPlatform returns the detected Platform for the running OS.
+func CurrentPlatform() Platform {
+	if runtime.GOOS == "windows" {
+		return PlatformWindows
+	}
+	return PlatformUnix
+}

--- a/internal/tool/ast/shadow.go
+++ b/internal/tool/ast/shadow.go
@@ -1,0 +1,91 @@
+package ast
+
+import (
+	"log"
+	"reflect"
+)
+
+// ShadowAnalyzer wraps a legacy CommandAnalyzer and runs the AST pipeline in
+// parallel (shadow mode). It always returns the legacy decision so there is
+// zero behavior change in Phase 4. Decision deltas are logged for analysis.
+//
+// Wire it in ShellTool.getAnalyzer() when FeatureASTShadow() is true.
+type ShadowAnalyzer struct {
+	legacy          legacyAnalyzer
+	astParser       Parser
+	policy          *PolicyEngine
+	allowedCommands map[string]map[string]bool
+}
+
+// legacyAnalyzer mirrors tool.CommandAnalyzer without importing the tool
+// package (which would create a circular dependency).
+type legacyAnalyzer interface {
+	Analyze(command string) LegacyAnalysis
+}
+
+// LegacyAnalysis is the subset of tool.CommandAnalysis that ShadowAnalyzer
+// needs. It is populated by the adapter shim in implementations.go.
+type LegacyAnalysis struct {
+	IsBlocked         bool
+	BlockReason       error
+	NeedsConfirmation bool
+}
+
+// NewShadowAnalyzer creates a ShadowAnalyzer. platform selects the parser
+// adapter; cwd is passed to the WindowsParser for path-resolution context;
+// allowedCommands is the merged allow-list from the permissions subsystem.
+func NewShadowAnalyzer(
+	legacy legacyAnalyzer,
+	platform Platform,
+	cwd string,
+	allowedCommands map[string]map[string]bool,
+) *ShadowAnalyzer {
+	return &ShadowAnalyzer{
+		legacy:          legacy,
+		astParser:       NewParser(platform, cwd),
+		policy:          &PolicyEngine{AllowedCommands: allowedCommands},
+		allowedCommands: allowedCommands,
+	}
+}
+
+// Analyze runs both the legacy analyzer and the AST pipeline, logs any
+// decision delta, and returns the legacy result (shadow mode — no enforcement).
+func (s *ShadowAnalyzer) Analyze(command string) LegacyAnalysis {
+	legacyResult := s.legacy.Analyze(command)
+
+	ir, err := s.astParser.Parse(command)
+	if err != nil {
+		log.Printf("[ast/shadow] parse error for %q: %v", truncate(command, 80), err)
+		return legacyResult
+	}
+
+	astDecision := s.policy.Decide(ir)
+
+	legacyNorm := LegacyAnalysis{
+		IsBlocked:         legacyResult.IsBlocked,
+		NeedsConfirmation: legacyResult.NeedsConfirmation,
+	}
+	astNorm := LegacyAnalysis{
+		IsBlocked:         astDecision.IsBlocked,
+		NeedsConfirmation: astDecision.NeedsConfirmation,
+	}
+
+	if !reflect.DeepEqual(legacyNorm, astNorm) {
+		log.Printf(
+			"[ast/shadow] DELTA command=%q legacy={blocked:%v confirm:%v} ast={blocked:%v confirm:%v} risk_flags=%v",
+			truncate(command, 80),
+			legacyResult.IsBlocked, legacyResult.NeedsConfirmation,
+			astDecision.IsBlocked, astDecision.NeedsConfirmation,
+			astDecision.ReasonCodes,
+		)
+	}
+
+	return legacyResult
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/tool/ast/shadow.go
+++ b/internal/tool/ast/shadow.go
@@ -1,9 +1,6 @@
 package ast
 
-import (
-	"log"
-	"reflect"
-)
+import "log"
 
 // ShadowAnalyzer wraps a legacy CommandAnalyzer and runs the AST pipeline in
 // parallel (shadow mode). It always returns the legacy decision so there is
@@ -11,10 +8,9 @@ import (
 //
 // Wire it in ShellTool.getAnalyzer() when FeatureASTShadow() is true.
 type ShadowAnalyzer struct {
-	legacy          legacyAnalyzer
-	astParser       Parser
-	policy          *PolicyEngine
-	allowedCommands map[string]map[string]bool
+	legacy    legacyAnalyzer
+	astParser Parser
+	policy    *PolicyEngine
 }
 
 // legacyAnalyzer mirrors tool.CommandAnalyzer without importing the tool
@@ -41,10 +37,9 @@ func NewShadowAnalyzer(
 	allowedCommands map[string]map[string]bool,
 ) *ShadowAnalyzer {
 	return &ShadowAnalyzer{
-		legacy:          legacy,
-		astParser:       NewParser(platform, cwd),
-		policy:          &PolicyEngine{AllowedCommands: allowedCommands},
-		allowedCommands: allowedCommands,
+		legacy:    legacy,
+		astParser: NewParser(platform, cwd),
+		policy:    &PolicyEngine{AllowedCommands: allowedCommands},
 	}
 }
 
@@ -61,16 +56,8 @@ func (s *ShadowAnalyzer) Analyze(command string) LegacyAnalysis {
 
 	astDecision := s.policy.Decide(ir)
 
-	legacyNorm := LegacyAnalysis{
-		IsBlocked:         legacyResult.IsBlocked,
-		NeedsConfirmation: legacyResult.NeedsConfirmation,
-	}
-	astNorm := LegacyAnalysis{
-		IsBlocked:         astDecision.IsBlocked,
-		NeedsConfirmation: astDecision.NeedsConfirmation,
-	}
-
-	if !reflect.DeepEqual(legacyNorm, astNorm) {
+	if legacyResult.IsBlocked != astDecision.IsBlocked ||
+		legacyResult.NeedsConfirmation != astDecision.NeedsConfirmation {
 		log.Printf(
 			"[ast/shadow] DELTA command=%q legacy={blocked:%v confirm:%v} ast={blocked:%v confirm:%v} risk_flags=%v",
 			truncate(command, 80),
@@ -89,3 +76,4 @@ func truncate(s string, max int) string {
 	}
 	return s[:max] + "…"
 }
+

--- a/internal/tool/ast/shadow.go
+++ b/internal/tool/ast/shadow.go
@@ -1,6 +1,20 @@
 package ast
 
-import "log"
+import (
+	"log"
+	"regexp"
+)
+
+// quotedStringRE matches single- and double-quoted string literals in shell
+// commands. Used to redact potential secrets before logging.
+var quotedStringRE = regexp.MustCompile(`"[^"]*"|'[^']*'`)
+
+// redactForLog replaces quoted literals with a placeholder and truncates.
+// This prevents credentials/tokens embedded in quoted arguments from
+// appearing in shadow-mode log output.
+func redactForLog(s string) string {
+	return truncate(quotedStringRE.ReplaceAllString(s, `"…"`), 80)
+}
 
 // ShadowAnalyzer wraps a legacy CommandAnalyzer and runs the AST pipeline in
 // parallel (shadow mode). It always returns the legacy decision so there is
@@ -50,7 +64,7 @@ func (s *ShadowAnalyzer) Analyze(command string) LegacyAnalysis {
 
 	ir, err := s.astParser.Parse(command)
 	if err != nil {
-		log.Printf("[ast/shadow] parse error for %q: %v", truncate(command, 80), err)
+		log.Printf("[ast/shadow] parse error for %s: %v", redactForLog(command), err)
 		return legacyResult
 	}
 
@@ -59,8 +73,8 @@ func (s *ShadowAnalyzer) Analyze(command string) LegacyAnalysis {
 	if legacyResult.IsBlocked != astDecision.IsBlocked ||
 		legacyResult.NeedsConfirmation != astDecision.NeedsConfirmation {
 		log.Printf(
-			"[ast/shadow] DELTA command=%q legacy={blocked:%v confirm:%v} ast={blocked:%v confirm:%v} risk_flags=%v",
-			truncate(command, 80),
+			"[ast/shadow] DELTA command=%s legacy={blocked:%v confirm:%v} ast={blocked:%v confirm:%v} risk_flags=%v",
+			redactForLog(command),
 			legacyResult.IsBlocked, legacyResult.NeedsConfirmation,
 			astDecision.IsBlocked, astDecision.NeedsConfirmation,
 			astDecision.ReasonCodes,

--- a/internal/tool/ast/snapshot_test.go
+++ b/internal/tool/ast/snapshot_test.go
@@ -17,9 +17,6 @@ type snapshotEntry struct {
 var unixCorpus = []snapshotEntry{
 	{"ls", false, false},
 	{"ls -la", false, false},
-	// KNOWN SHADOW DELTA: legacy BashAnalyzer rejects -rt (not in flag allowlist).
-	// The AST policy engine does not perform flag-level validation; flag granularity
-	// is a legacy-layer concern. This delta is expected and logged in shadow mode.
 	{"ls -rt", false, false},
 	{"date", false, false},
 	{"echo 'hello world'", false, false},
@@ -44,7 +41,7 @@ func TestUnixCorpusSnapshot(t *testing.T) {
 	p := &UnixParser{}
 	pe := &PolicyEngine{
 		AllowedCommands: map[string]map[string]bool{
-			"ls":   {},
+			"ls":   {"-la": true, "-rt": true},
 			"grep": {},
 			"pwd":  {},
 			"date": {},

--- a/internal/tool/ast/snapshot_test.go
+++ b/internal/tool/ast/snapshot_test.go
@@ -1,0 +1,72 @@
+package ast
+
+import (
+	"testing"
+)
+
+// snapshotEntry records the expected Decision for a command in the corpus.
+// These are derived from the existing BashAnalyzer/PowerShellAnalyzer baselines.
+type snapshotEntry struct {
+	command           string
+	wantBlocked       bool
+	wantConfirm       bool
+}
+
+// unixCorpus mirrors the table in bash_analyzer_test.go so that the AST
+// policy engine can be validated against the established baseline.
+var unixCorpus = []snapshotEntry{
+	{"ls", false, false},
+	{"ls -la", false, false},
+	// KNOWN SHADOW DELTA: legacy BashAnalyzer rejects -rt (not in flag allowlist).
+	// The AST policy engine does not perform flag-level validation; flag granularity
+	// is a legacy-layer concern. This delta is expected and logged in shadow mode.
+	{"ls -rt", false, false},
+	{"date", false, false},
+	{"echo 'hello world'", false, false},
+	{"echo $HOME", false, true},             // expansion
+	{"cd /tmp", true, true},                 // cd blocked
+	{"ls > out.txt", true, true},            // redirect blocked
+	{"echo foo >> bar.txt", true, true},     // redirect blocked
+	{"ls | grep foo", false, false},         // safe pipe (allowlisted in corpus)
+	{"(ls)", false, true},                   // subshell
+	{"echo $(ls)", false, true},             // subshell
+	{"ls; pwd", false, false},               // safe compound
+	{"mkdir foo", false, true},              // unknown command
+	{"cd /tmp; ls", true, true},             // cd in compound
+	{"ls > /dev/null", false, false},        // safe redirect
+	{"ls 2>&1", false, false},               // safe fd dup
+}
+
+// TestUnixCorpusSnapshot verifies the AST policy engine against the
+// known-good baseline corpus. Commands that reference the allow-list
+// (e.g. "ls | grep") use a pre-seeded AllowedCommands map.
+func TestUnixCorpusSnapshot(t *testing.T) {
+	p := &UnixParser{}
+	pe := &PolicyEngine{
+		AllowedCommands: map[string]map[string]bool{
+			"ls":   {},
+			"grep": {},
+			"pwd":  {},
+			"date": {},
+			"echo": {},
+			"head": {},
+			"tail": {},
+			"git":  {},
+			"go":   {},
+		},
+	}
+
+	for _, tc := range unixCorpus {
+		t.Run(tc.command, func(t *testing.T) {
+			ir, _ := p.Parse(tc.command)
+			d := pe.Decide(ir)
+
+			if d.IsBlocked != tc.wantBlocked {
+				t.Errorf("IsBlocked: got %v want %v (flags=%v)", d.IsBlocked, tc.wantBlocked, ir.RiskFlags)
+			}
+			if d.NeedsConfirmation != tc.wantConfirm {
+				t.Errorf("NeedsConfirmation: got %v want %v (flags=%v)", d.NeedsConfirmation, tc.wantConfirm, ir.RiskFlags)
+			}
+		})
+	}
+}

--- a/internal/tool/ast/snapshot_test.go
+++ b/internal/tool/ast/snapshot_test.go
@@ -7,9 +7,9 @@ import (
 // snapshotEntry records the expected Decision for a command in the corpus.
 // These are derived from the existing BashAnalyzer/PowerShellAnalyzer baselines.
 type snapshotEntry struct {
-	command           string
-	wantBlocked       bool
-	wantConfirm       bool
+	command     string
+	wantBlocked bool
+	wantConfirm bool
 }
 
 // unixCorpus mirrors the table in bash_analyzer_test.go so that the AST
@@ -23,18 +23,57 @@ var unixCorpus = []snapshotEntry{
 	{"ls -rt", false, false},
 	{"date", false, false},
 	{"echo 'hello world'", false, false},
-	{"echo $HOME", false, true},             // expansion
-	{"cd /tmp", true, true},                 // cd blocked
-	{"ls > out.txt", true, true},            // redirect blocked
-	{"echo foo >> bar.txt", true, true},     // redirect blocked
-	{"ls | grep foo", false, false},         // safe pipe (allowlisted in corpus)
-	{"(ls)", false, true},                   // subshell
-	{"echo $(ls)", false, true},             // subshell
-	{"ls; pwd", false, false},               // safe compound
-	{"mkdir foo", false, true},              // unknown command
-	{"cd /tmp; ls", true, true},             // cd in compound
-	{"ls > /dev/null", false, false},        // safe redirect
-	{"ls 2>&1", false, false},               // safe fd dup
+	{"echo $HOME", false, true},         // expansion
+	{"cd /tmp", true, true},             // cd blocked
+	{"ls > out.txt", true, true},        // redirect blocked
+	{"echo foo >> bar.txt", true, true}, // redirect blocked
+	{"ls | grep foo", false, false},     // safe pipe (allowlisted in corpus)
+	{"(ls)", false, true},               // subshell
+	{"echo $(ls)", false, true},         // subshell
+	{"ls; pwd", false, false},           // safe compound
+	{"mkdir foo", false, true},          // unknown command
+	{"cd /tmp; ls", true, true},         // cd in compound
+	{"ls > /dev/null", false, false},    // safe redirect
+	{"ls 2>&1", false, false},           // safe fd dup
+}
+
+// windowsCorpus mirrors the PowerShellAnalyzer test expectations for the
+// Windows policy path. Tests run through the PolicyEngine with Windows
+// built-in cmdlets pre-seeded, mirroring the enforcement-mode allow-list.
+var windowsCorpus = []snapshotEntry{
+	// Safe read-only cmdlets — auto-approved via built-in allowlist.
+	{"Get-ChildItem", false, false},
+	{"Get-ChildItem -Recurse", false, false},
+	{"Get-Content README.md", false, false},
+	{"Get-Date", false, false},
+	{"Get-Location", false, false},
+	{"Write-Output hello", false, false},
+	{"whoami", false, false},
+	{"ls", false, false},
+	{"pwd", false, false},
+	// Risky: Invoke-Expression.
+	{"Invoke-Expression 'rm -rf /'", false, true},
+	{"iex 'bad'", false, true},
+	// Risky: variable expansion.
+	{"Write-Output $env:USERNAME", false, true},
+	// Risky: subshell (sub-expression).
+	{"Write-Output $(Get-Date)", false, true},
+	// Risky: script block.
+	{"Invoke-Command -ScriptBlock { rm -rf / }", false, true},
+	// cd / Set-Location — hard blocked.
+	{"Set-Location C:\\tmp", true, true},
+	{"cd C:\\tmp", true, true},
+	{"sl /tmp", true, true},
+	{"Push-Location C:\\tmp", true, true},
+	{"pushd C:\\tmp", true, true},
+	// Redirect to file — hard blocked.
+	{"Get-ChildItem > out.txt", true, true},
+	// Safe pipe between known cmdlets.
+	{"Get-ChildItem | Select-String foo", false, false},
+	// Operator separating unknown cmdlet → confirm.
+	{"Get-ChildItem; Invoke-Expression 'x'", false, true},
+	// Dangerous Windows-specific flags.
+	{"powershell -EncodedCommand abc", false, true},
 }
 
 // TestUnixCorpusSnapshot verifies the AST policy engine against the
@@ -70,3 +109,53 @@ func TestUnixCorpusSnapshot(t *testing.T) {
 		})
 	}
 }
+
+// windowsBuiltinPE returns a PolicyEngine pre-seeded with the Windows
+// built-in safe cmdlets, mirroring what newASTAnalyzer does in enforcement mode.
+func windowsBuiltinPE() *PolicyEngine {
+	builtins := []string{
+		"cat", "date", "dir", "echo",
+		"gc", "gci", "get-childitem", "get-content", "get-date", "get-location",
+		"ls", "measure-object", "pwd",
+		"select-string", "sls", "type", "whoami", "write-output", "write-host",
+	}
+	m := make(map[string]map[string]bool, len(builtins))
+	for _, cmd := range builtins {
+		m[cmd] = map[string]bool{}
+	}
+	return &PolicyEngine{AllowedCommands: m}
+}
+
+// TestWindowsCorpusSnapshot verifies the AST policy engine + Windows
+// built-in allowlist against the known-good baseline corpus for Windows.
+// It uses synthetic IR fixtures produced by the UnixParser as stand-ins
+// so the test runs on all platforms without requiring pwsh.
+func TestWindowsCorpusSnapshot(t *testing.T) {
+	pe := windowsBuiltinPE()
+
+	// Use the real Windows bridge parser if available, otherwise fall back to
+	// a synthetic IR approach that exercises the policy engine logic.
+	p := &WindowsParser{}
+
+	for _, tc := range windowsCorpus {
+		t.Run(tc.command, func(t *testing.T) {
+			ir, err := p.Parse(tc.command)
+			if err != nil && len(ir.ParseErrors) > 0 {
+				// Bridge unavailable on this platform — skip live bridge tests.
+				t.Skip("windows bridge not available")
+			}
+
+			d := pe.Decide(ir)
+
+			if d.IsBlocked != tc.wantBlocked {
+				t.Errorf("IsBlocked: got %v want %v (flags=%v, errs=%v)",
+					d.IsBlocked, tc.wantBlocked, ir.RiskFlags, ir.ParseErrors)
+			}
+			if d.NeedsConfirmation != tc.wantConfirm {
+				t.Errorf("NeedsConfirmation: got %v want %v (flags=%v, errs=%v)",
+					d.NeedsConfirmation, tc.wantConfirm, ir.RiskFlags, ir.ParseErrors)
+			}
+		})
+	}
+}
+

--- a/internal/tool/ast/snapshot_test.go
+++ b/internal/tool/ast/snapshot_test.go
@@ -37,47 +37,6 @@ var unixCorpus = []snapshotEntry{
 	{"ls 2>&1", false, false},           // safe fd dup
 }
 
-// windowsCorpus mirrors the PowerShellAnalyzer test expectations for the
-// Windows policy path. Tests run through the PolicyEngine with Windows
-// built-in cmdlets pre-seeded, mirroring the enforcement-mode allow-list.
-var windowsCorpus = []snapshotEntry{
-	// Safe read-only cmdlets — auto-approved via built-in allowlist.
-	{"Get-ChildItem", false, false},
-	{"Get-ChildItem -Recurse", false, false},
-	{"Get-Content README.md", false, false},
-	{"Get-Date", false, false},
-	{"Get-Location", false, false},
-	{"Write-Output hello", false, false},
-	{"whoami", false, false},
-	{"ls", false, false},
-	{"pwd", false, false},
-	// Risky: Invoke-Expression.
-	{"Invoke-Expression 'rm -rf /'", false, true},
-	{"iex 'bad'", false, true},
-	// Risky: variable expansion.
-	{"Write-Output $env:USERNAME", false, true},
-	// Risky: subshell (sub-expression).
-	{"Write-Output $(Get-Date)", false, true},
-	// Risky: script block.
-	{"Invoke-Command -ScriptBlock { rm -rf / }", false, true},
-	// cd / Set-Location — hard blocked.
-	{"Set-Location C:\\tmp", true, true},
-	{"cd C:\\tmp", true, true},
-	{"sl /tmp", true, true},
-	{"Push-Location C:\\tmp", true, true},
-	{"pushd C:\\tmp", true, true},
-	// Redirect to file — hard blocked.
-	{"Get-ChildItem > out.txt", true, true},
-	// Safe pipe between known cmdlets.
-	{"Get-ChildItem | Select-String foo", false, false},
-	// Operator separating unknown cmdlet → confirm.
-	{"Get-ChildItem; Invoke-Expression 'x'", false, true},
-	// Destructive: Remove-Item — requires confirmation, not blocked.
-	{"Remove-Item foo.txt", false, true},
-	// Dangerous Windows-specific flags.
-	{"powershell -EncodedCommand abc", false, true},
-}
-
 // TestUnixCorpusSnapshot verifies the AST policy engine against the
 // known-good baseline corpus. Commands that reference the allow-list
 // (e.g. "ls | grep") use a pre-seeded AllowedCommands map.
@@ -107,55 +66,6 @@ func TestUnixCorpusSnapshot(t *testing.T) {
 			}
 			if d.NeedsConfirmation != tc.wantConfirm {
 				t.Errorf("NeedsConfirmation: got %v want %v (flags=%v)", d.NeedsConfirmation, tc.wantConfirm, ir.RiskFlags)
-			}
-		})
-	}
-}
-
-// windowsBuiltinPE returns a PolicyEngine pre-seeded with the Windows
-// built-in safe cmdlets, mirroring what newASTAnalyzer does in enforcement mode.
-func windowsBuiltinPE() *PolicyEngine {
-	builtins := []string{
-		"cat", "date", "dir", "echo",
-		"gc", "gci", "get-childitem", "get-content", "get-date", "get-location",
-		"ls", "measure-object", "pwd",
-		"select-string", "sls", "type", "whoami", "write-host", "write-output",
-	}
-	m := make(map[string]map[string]bool, len(builtins))
-	for _, cmd := range builtins {
-		m[cmd] = map[string]bool{}
-	}
-	return &PolicyEngine{AllowedCommands: m}
-}
-
-// TestWindowsCorpusSnapshot verifies the AST policy engine + Windows
-// built-in allowlist against the known-good baseline corpus for Windows.
-// It uses synthetic IR fixtures produced by the UnixParser as stand-ins
-// so the test runs on all platforms without requiring pwsh.
-func TestWindowsCorpusSnapshot(t *testing.T) {
-	pe := windowsBuiltinPE()
-
-	// Use the real Windows bridge parser if available, otherwise fall back to
-	// a synthetic IR approach that exercises the policy engine logic.
-	p := &WindowsParser{}
-
-	for _, tc := range windowsCorpus {
-		t.Run(tc.command, func(t *testing.T) {
-			ir, err := p.Parse(tc.command)
-			if err != nil && len(ir.ParseErrors) > 0 {
-				// Bridge unavailable on this platform — skip live bridge tests.
-				t.Skip("windows bridge not available")
-			}
-
-			d := pe.Decide(ir)
-
-			if d.IsBlocked != tc.wantBlocked {
-				t.Errorf("IsBlocked: got %v want %v (flags=%v, errs=%v)",
-					d.IsBlocked, tc.wantBlocked, ir.RiskFlags, ir.ParseErrors)
-			}
-			if d.NeedsConfirmation != tc.wantConfirm {
-				t.Errorf("NeedsConfirmation: got %v want %v (flags=%v, errs=%v)",
-					d.NeedsConfirmation, tc.wantConfirm, ir.RiskFlags, ir.ParseErrors)
 			}
 		})
 	}

--- a/internal/tool/ast/snapshot_test.go
+++ b/internal/tool/ast/snapshot_test.go
@@ -72,6 +72,8 @@ var windowsCorpus = []snapshotEntry{
 	{"Get-ChildItem | Select-String foo", false, false},
 	// Operator separating unknown cmdlet → confirm.
 	{"Get-ChildItem; Invoke-Expression 'x'", false, true},
+	// Destructive: Remove-Item — requires confirmation, not blocked.
+	{"Remove-Item foo.txt", false, true},
 	// Dangerous Windows-specific flags.
 	{"powershell -EncodedCommand abc", false, true},
 }
@@ -117,7 +119,7 @@ func windowsBuiltinPE() *PolicyEngine {
 		"cat", "date", "dir", "echo",
 		"gc", "gci", "get-childitem", "get-content", "get-date", "get-location",
 		"ls", "measure-object", "pwd",
-		"select-string", "sls", "type", "whoami", "write-output", "write-host",
+		"select-string", "sls", "type", "whoami", "write-host", "write-output",
 	}
 	m := make(map[string]map[string]bool, len(builtins))
 	for _, cmd := range builtins {

--- a/internal/tool/ast/snapshot_windows_test.go
+++ b/internal/tool/ast/snapshot_windows_test.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package ast
+
+import "testing"
+
+// windowsCorpus mirrors the PowerShellAnalyzer test expectations for the
+// Windows policy path. Tests run through the PolicyEngine with Windows
+// built-in cmdlets pre-seeded, mirroring the enforcement-mode allow-list.
+var windowsCorpus = []snapshotEntry{
+	// Safe read-only cmdlets — auto-approved via built-in allowlist.
+	{"Get-ChildItem", false, false},
+	{"Get-ChildItem -Recurse", false, false},
+	{"Get-Content README.md", false, false},
+	{"Get-Date", false, false},
+	{"Get-Location", false, false},
+	{"Write-Output hello", false, false},
+	{"whoami", false, false},
+	{"ls", false, false},
+	{"pwd", false, false},
+	// Risky: Invoke-Expression.
+	{"Invoke-Expression 'rm -rf /'", false, true},
+	{"iex 'bad'", false, true},
+	// Risky: variable expansion.
+	{"Write-Output $env:USERNAME", false, true},
+	// Risky: subshell (sub-expression).
+	{"Write-Output $(Get-Date)", false, true},
+	// Risky: Invoke-Command (dynamic eval). The script-block syntax itself is
+	// not the risk signal — invoke-command is.
+	{"Invoke-Command -ScriptBlock { rm -rf / }", false, true},
+	// cd / Set-Location — hard blocked.
+	{"Set-Location C:\\tmp", true, true},
+	{"cd C:\\tmp", true, true},
+	{"sl /tmp", true, true},
+	{"Push-Location C:\\tmp", true, true},
+	{"pushd C:\\tmp", true, true},
+	// Redirect to file — hard blocked.
+	{"Get-ChildItem > out.txt", true, true},
+	// Safe pipe between known cmdlets.
+	{"Get-ChildItem | Select-String foo", false, false},
+	// Operator separating unknown cmdlet → confirm.
+	{"Get-ChildItem; Invoke-Expression 'x'", false, true},
+	// Destructive: Remove-Item — requires confirmation, not blocked.
+	{"Remove-Item foo.txt", false, true},
+	// Script block as argument — idiomatic PS, must NOT emit ReasonSubshell.
+	{"Get-ChildItem | ForEach-Object { Write-Output 'done' }", false, true},
+	// Dangerous Windows-specific flags.
+	{"powershell -EncodedCommand abc", false, true},
+}
+
+// windowsBuiltinPE returns a PolicyEngine pre-seeded with the Windows
+// built-in safe cmdlets, mirroring what newASTAnalyzer does in enforcement mode.
+func windowsBuiltinPE() *PolicyEngine {
+	builtins := []string{
+		"cat", "date", "dir", "echo",
+		"gc", "gci", "get-childitem", "get-content", "get-date", "get-location",
+		"ls", "measure-object", "pwd",
+		"select-string", "sls", "type", "whoami", "write-host", "write-output",
+	}
+	m := make(map[string]map[string]bool, len(builtins))
+	for _, cmd := range builtins {
+		m[cmd] = map[string]bool{}
+	}
+	return &PolicyEngine{AllowedCommands: m}
+}
+
+// TestWindowsCorpusSnapshot verifies the PolicyEngine + Windows built-in
+// allowlist against the known-good baseline corpus.  Requires pwsh; restricted
+// to Windows builds via the go:build tag.
+func TestWindowsCorpusSnapshot(t *testing.T) {
+	skipIfNoPwsh(t)
+	pe := windowsBuiltinPE()
+	p := &WindowsParser{}
+
+	for _, tc := range windowsCorpus {
+		t.Run(tc.command, func(t *testing.T) {
+			ir, _ := p.Parse(tc.command)
+			d := pe.Decide(ir)
+
+			if d.IsBlocked != tc.wantBlocked {
+				t.Errorf("IsBlocked: got %v want %v (flags=%v, errs=%v)",
+					d.IsBlocked, tc.wantBlocked, ir.RiskFlags, ir.ParseErrors)
+			}
+			if d.NeedsConfirmation != tc.wantConfirm {
+				t.Errorf("NeedsConfirmation: got %v want %v (flags=%v, errs=%v)",
+					d.NeedsConfirmation, tc.wantConfirm, ir.RiskFlags, ir.ParseErrors)
+			}
+		})
+	}
+}

--- a/internal/tool/ast/snapshot_windows_test.go
+++ b/internal/tool/ast/snapshot_windows_test.go
@@ -21,7 +21,9 @@ var windowsCorpus = []snapshotEntry{
 	// Risky: Invoke-Expression.
 	{"Invoke-Expression 'rm -rf /'", false, true},
 	{"iex 'bad'", false, true},
-	// Risky: variable expansion.
+	// $true/$false/$null — language constants, must not trigger expansion risk.
+	{"Write-Output $true", false, false},
+	// $env:VAR IS a dynamic expansion — must require confirmation.
 	{"Write-Output $env:USERNAME", false, true},
 	// Risky: subshell (sub-expression).
 	{"Write-Output $(Get-Date)", false, true},

--- a/internal/tool/ast/unix_adapter.go
+++ b/internal/tool/ast/unix_adapter.go
@@ -1,0 +1,152 @@
+package ast
+
+import (
+	"fmt"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// UnixParser implements Parser for Unix/bash/sh shells via mvdan.cc/sh/v3.
+// It walks the native AST and maps nodes to ParsedIR risk signals.
+type UnixParser struct{}
+
+// Parse parses command as a Unix/bash shell statement and returns a ParsedIR.
+// It never executes the command; parsing is purely syntactic.
+func (u *UnixParser) Parse(command string) (ParsedIR, error) {
+	ir := emptyIR(PlatformUnix)
+
+	parser := syntax.NewParser()
+	f, err := parser.Parse(strings.NewReader(command), "")
+	if err != nil {
+		ir.ParseErrors = append(ir.ParseErrors, err.Error())
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/unix: %w", err)
+	}
+
+	seenCmds := map[string]bool{}
+	seenOps := map[string]bool{}
+	seenRedirects := map[string]bool{}
+	seenExpansions := map[string]bool{}
+	seenRisk := map[ReasonCode]bool{}
+
+	// Multiple top-level statements imply ';' as a separator.
+	if len(f.Stmts) > 1 {
+		addStringUnique(&ir.Operators, seenOps, ";")
+		addRiskFlag(&ir, seenRisk, ReasonOperator)
+	}
+
+	syntax.Walk(f, func(node syntax.Node) bool {
+		if node == nil {
+			return false
+		}
+		switch n := node.(type) {
+		case *syntax.CallExpr:
+			if len(n.Args) > 0 {
+				name := unixResolveWord(n.Args[0])
+				if name != "" && !strings.Contains(name, "/") {
+					addStringUnique(&ir.Commands, seenCmds, name)
+					if name == "cd" {
+						addRiskFlag(&ir, seenRisk, ReasonCd)
+					}
+				}
+			}
+
+		case *syntax.BinaryCmd:
+			op := n.Op.String()
+			addStringUnique(&ir.Operators, seenOps, op)
+			addRiskFlag(&ir, seenRisk, ReasonOperator)
+
+		case *syntax.Redirect:
+			switch n.Op {
+			case syntax.RdrOut, syntax.AppOut, syntax.RdrAll, syntax.AppAll,
+				syntax.RdrClob, syntax.AppClob:
+				word := unixResolveWord(n.Word)
+				if !unixIsSafeRedirectTarget(word) {
+					addStringUnique(&ir.Redirects, seenRedirects, ">")
+					addRiskFlag(&ir, seenRisk, ReasonRedirect)
+				}
+			case syntax.DplOut:
+				word := unixResolveWord(n.Word)
+				if !unixIsNumericFd(word) && !unixIsSafeRedirectTarget(word) {
+					addStringUnique(&ir.Redirects, seenRedirects, ">&")
+					addRiskFlag(&ir, seenRisk, ReasonRedirect)
+				}
+			}
+
+		case *syntax.ParamExp:
+			addStringUnique(&ir.Expansions, seenExpansions, "var")
+			addRiskFlag(&ir, seenRisk, ReasonExpansion)
+
+		case *syntax.ArithmExp, *syntax.ArithmCmd:
+			addStringUnique(&ir.Expansions, seenExpansions, "arith")
+			addRiskFlag(&ir, seenRisk, ReasonExpansion)
+
+		case *syntax.CmdSubst:
+			addStringUnique(&ir.Expansions, seenExpansions, "subshell")
+			addRiskFlag(&ir, seenRisk, ReasonSubshell)
+
+		case *syntax.ProcSubst:
+			addStringUnique(&ir.Expansions, seenExpansions, "proc_subst")
+			addRiskFlag(&ir, seenRisk, ReasonSubshell)
+
+		case *syntax.Subshell:
+			addStringUnique(&ir.Expansions, seenExpansions, "subshell")
+			addRiskFlag(&ir, seenRisk, ReasonSubshell)
+
+		case *syntax.Block, *syntax.IfClause, *syntax.WhileClause,
+			*syntax.ForClause, *syntax.CaseClause:
+			addRiskFlag(&ir, seenRisk, ReasonOperator)
+		}
+		return true
+	})
+
+	return ir, nil
+}
+
+// unixResolveWord attempts to statically resolve a syntax.Word to a plain
+// string. Returns "" if the word contains dynamic parts (variables, subshells).
+func unixResolveWord(w *syntax.Word) string {
+	if w == nil || len(w.Parts) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range w.Parts {
+		switch p := part.(type) {
+		case *syntax.Lit:
+			sb.WriteString(p.Value)
+		case *syntax.SglQuoted:
+			sb.WriteString(p.Value)
+		case *syntax.DblQuoted:
+			for _, qp := range p.Parts {
+				if lit, ok := qp.(*syntax.Lit); ok {
+					sb.WriteString(lit.Value)
+				} else {
+					return "" // dynamic content inside double-quotes
+				}
+			}
+		default:
+			return "" // dynamic word part — cannot resolve statically
+		}
+	}
+	return sb.String()
+}
+
+func unixIsSafeRedirectTarget(word string) bool {
+	return word == "/dev/null" || word == "/dev/stdout" || word == "/dev/stderr"
+}
+
+func unixIsNumericFd(s string) bool {
+	if s == "-" {
+		return true
+	}
+	if len(s) == 0 {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tool/ast/unix_adapter.go
+++ b/internal/tool/ast/unix_adapter.go
@@ -29,6 +29,7 @@ func (u *UnixParser) Parse(command string) (ParsedIR, error) {
 	seenRedirects := map[string]bool{}
 	seenExpansions := map[string]bool{}
 	seenRisk := map[ReasonCode]bool{}
+	seenCmdFlags := map[string]map[string]bool{} // command → flag → seen
 
 	// Multiple top-level statements imply ';' as a separator.
 	if len(f.Stmts) > 1 {
@@ -48,6 +49,28 @@ func (u *UnixParser) Parse(command string) (ParsedIR, error) {
 					addStringUnique(&ir.Commands, seenCmds, name)
 					if name == "cd" {
 						addRiskFlag(&ir, seenRisk, ReasonCd)
+					}
+					// Collect flags for policy engine allow-list matching.
+					if _, ok := seenCmdFlags[name]; !ok {
+						seenCmdFlags[name] = map[string]bool{}
+					}
+					for _, arg := range n.Args[1:] {
+						val := unixResolveWord(arg)
+						if !strings.HasPrefix(val, "-") {
+							continue
+						}
+						// Normalize --flag=value → --flag; -N (numeric) → -*.
+						flagKey := val
+						if idx := strings.Index(val, "="); idx != -1 {
+							flagKey = val[:idx]
+						}
+						if unixIsNumericFlag(val) {
+							flagKey = "-*"
+						}
+						if !seenCmdFlags[name][flagKey] {
+							seenCmdFlags[name][flagKey] = true
+							ir.CommandArgs[name] = append(ir.CommandArgs[name], flagKey)
+						}
 					}
 				}
 			}
@@ -134,6 +157,19 @@ func unixResolveWord(w *syntax.Word) string {
 
 func unixIsSafeRedirectTarget(word string) bool {
 	return word == "/dev/null" || word == "/dev/stdout" || word == "/dev/stderr"
+}
+
+// unixIsNumericFlag returns true for flags like -5, -100 (only digits after the dash).
+func unixIsNumericFlag(s string) bool {
+	if len(s) < 2 || s[0] != '-' {
+		return false
+	}
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func unixIsNumericFd(s string) bool {

--- a/internal/tool/ast/unix_adapter_test.go
+++ b/internal/tool/ast/unix_adapter_test.go
@@ -1,0 +1,163 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestUnixParser_SimpleCommands(t *testing.T) {
+	p := &UnixParser{}
+	tests := []struct {
+		command     string
+		wantCmds    []string
+		wantRisk    []ReasonCode
+		wantBlocked bool // proxy: ReasonCd or ReasonRedirect present
+	}{
+		{
+			command:  "ls",
+			wantCmds: []string{"ls"},
+			wantRisk: nil,
+		},
+		{
+			command:  "ls -la",
+			wantCmds: []string{"ls"},
+			wantRisk: nil,
+		},
+		{
+			command:  "ls | grep foo",
+			wantCmds: []string{"ls", "grep"},
+			wantRisk: []ReasonCode{ReasonOperator},
+		},
+		{
+			command:  "ls; pwd",
+			wantCmds: []string{"ls", "pwd"},
+			wantRisk: []ReasonCode{ReasonOperator},
+		},
+		{
+			command:  "echo $HOME",
+			wantCmds: []string{"echo"},
+			wantRisk: []ReasonCode{ReasonExpansion},
+		},
+		{
+			command:     "cd /tmp",
+			wantCmds:    []string{"cd"},
+			wantBlocked: true,
+			wantRisk:    []ReasonCode{ReasonCd},
+		},
+		{
+			command:     "ls > out.txt",
+			wantCmds:    []string{"ls"},
+			wantBlocked: true,
+			wantRisk:    []ReasonCode{ReasonRedirect},
+		},
+		{
+			command:  "ls > /dev/null",
+			wantCmds: []string{"ls"},
+			wantRisk: nil, // safe redirect — no ReasonRedirect
+		},
+		{
+			command:  "echo $(ls)",
+			wantCmds: []string{"echo"},
+			wantRisk: []ReasonCode{ReasonSubshell},
+		},
+		{
+			command:  "(ls)",
+			wantCmds: []string{"ls"},
+			wantRisk: []ReasonCode{ReasonSubshell},
+		},
+		{
+			command:  "git log --oneline",
+			wantCmds: []string{"git"},
+			wantRisk: nil,
+		},
+		{
+			command:  "go mod tidy && go test ./...",
+			wantCmds: []string{"go"},
+			wantRisk: []ReasonCode{ReasonOperator},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.command, func(t *testing.T) {
+			ir, _ := p.Parse(tc.command)
+
+			if ir.Version != IRVersion {
+				t.Errorf("Version: got %q want %q", ir.Version, IRVersion)
+			}
+			if ir.Platform != PlatformUnix {
+				t.Errorf("Platform: got %q want %q", ir.Platform, PlatformUnix)
+			}
+
+			for _, wantCmd := range tc.wantCmds {
+				found := false
+				for _, c := range ir.Commands {
+					if c == wantCmd {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected command %q in %v", wantCmd, ir.Commands)
+				}
+			}
+
+			for _, wantRC := range tc.wantRisk {
+				if !hasRisk(ir, wantRC) {
+					t.Errorf("expected risk flag %q in %v", wantRC, ir.RiskFlags)
+				}
+			}
+
+			gotBlocked := hasRisk(ir, ReasonCd) || hasRisk(ir, ReasonRedirect)
+			if gotBlocked != tc.wantBlocked {
+				t.Errorf("wantBlocked=%v but blocking risk flags present=%v (flags=%v)",
+					tc.wantBlocked, gotBlocked, ir.RiskFlags)
+			}
+		})
+	}
+}
+
+func TestUnixParser_SyntaxError(t *testing.T) {
+	p := &UnixParser{}
+	ir, err := p.Parse("echo $(")
+	if err == nil {
+		t.Error("expected error for invalid syntax")
+	}
+	if !hasRisk(ir, ReasonSyntaxError) {
+		t.Errorf("expected ReasonSyntaxError in %v", ir.RiskFlags)
+	}
+	if len(ir.ParseErrors) == 0 {
+		t.Error("expected non-empty ParseErrors")
+	}
+}
+
+func TestUnixParser_SafeRedirectsNotFlagged(t *testing.T) {
+	p := &UnixParser{}
+	for _, cmd := range []string{
+		"ls > /dev/null",
+		"ls > /dev/stdout",
+		"ls 2> /dev/stderr",
+		"ls 2>&1",
+		"ls 2>&-",
+	} {
+		ir, _ := p.Parse(cmd)
+		if hasRisk(ir, ReasonRedirect) {
+			t.Errorf("%q: got ReasonRedirect but should be safe", cmd)
+		}
+	}
+}
+
+func TestUnixParser_Operators(t *testing.T) {
+	p := &UnixParser{}
+	ir, _ := p.Parse("git status && go test ./...")
+	if !hasRisk(ir, ReasonOperator) {
+		t.Error("expected ReasonOperator for &&")
+	}
+	foundOp := false
+	for _, op := range ir.Operators {
+		if op == "&&" {
+			foundOp = true
+		}
+	}
+	if !foundOp {
+		t.Errorf("expected && in Operators, got %v", ir.Operators)
+	}
+}

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -1,14 +1,14 @@
 package ast
 
 import (
-	"bytes"
-	"context"
-	_ "embed"
-	"encoding/base64"
-	"encoding/json"
+"bufio"
+"bytes"
+_ "embed"
+"encoding/base64"
+"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 	"unicode/utf16"
@@ -17,191 +17,310 @@ import (
 //go:embed ps_bridge.ps1
 var psBridgeScript []byte
 
-// WindowsParser implements Parser for PowerShell using an out-of-process pwsh
-// bridge that invokes System.Management.Automation.Language.Parser::ParseInput.
+// WindowsParser implements Parser for PowerShell using a persistent pwsh
+// bridge process that invokes System.Management.Automation.Language.Parser.
 // The bridge NEVER executes the command; it only parses and emits JSON IR.
+//
+// The first Parse call starts the bridge process; subsequent calls reuse it.
+// On any transport failure the bridge is killed and restarted on the next call.
 //
 // On non-Windows hosts (or when pwsh is unavailable) Parse fails closed:
 // it returns a ParsedIR with ReasonSyntaxError and a non-nil error.
 type WindowsParser struct {
-	// Cwd is the working directory context used for path-resolution heuristics
-	// in the policy engine. The bridge script itself does not use it.
-	Cwd string
+// Cwd is the working directory context used for path-resolution heuristics
+// in the policy engine. The bridge script itself does not use it.
+Cwd string
 }
 
 var (
-	winPSPath     string
-	winPSPathOnce sync.Once
+winPSPath     string
+winPSPathOnce sync.Once
 
-	winEncodedBridge     string
-	winEncodedBridgeOnce sync.Once
+winEncodedBridge     string
+winEncodedBridgeOnce sync.Once
 )
 
 func getWindowsShellPath() string {
-	winPSPathOnce.Do(func() {
-		if p, err := exec.LookPath("pwsh.exe"); err == nil {
-			winPSPath = p
-			return
-		}
-		if p, err := exec.LookPath("powershell.exe"); err == nil {
-			winPSPath = p
-			return
-		}
-		winPSPath = ""
-	})
-	return winPSPath
+winPSPathOnce.Do(func() {
+if p, err := exec.LookPath("pwsh.exe"); err == nil {
+winPSPath = p
+return
+}
+if p, err := exec.LookPath("powershell.exe"); err == nil {
+winPSPath = p
+return
+}
+winPSPath = ""
+})
+return winPSPath
 }
 
 // encodePSScript base64-encodes a PowerShell script for -EncodedCommand.
 func encodePSScript(script []byte) string {
-	u16 := utf16.Encode([]rune(string(script)))
-	b := make([]byte, len(u16)*2)
-	for i, r := range u16 {
-		b[i*2] = byte(r)
-		b[i*2+1] = byte(r >> 8)
-	}
-	return base64.StdEncoding.EncodeToString(b)
+u16 := utf16.Encode([]rune(string(script)))
+b := make([]byte, len(u16)*2)
+for i, r := range u16 {
+b[i*2] = byte(r)
+b[i*2+1] = byte(r >> 8)
+}
+return base64.StdEncoding.EncodeToString(b)
 }
 
 // getBridgeEncoded returns the cached base64-encoded bridge script.
 func getBridgeEncoded() string {
-	winEncodedBridgeOnce.Do(func() {
-		winEncodedBridge = encodePSScript(psBridgeScript)
-	})
-	return winEncodedBridge
+winEncodedBridgeOnce.Do(func() {
+winEncodedBridge = encodePSScript(psBridgeScript)
+})
+return winEncodedBridge
 }
 
 const maxCommandBytes = 65536
 
 // sanitizeCommand rejects inputs that could corrupt the bridge transport:
-// null bytes, carriage-return-only line endings that survive the PS stdin
-// reader, or commands exceeding the size guard.
+// null bytes or commands exceeding the size guard.
 func sanitizeCommand(command string) error {
-	if len(command) > maxCommandBytes {
-		return fmt.Errorf("command exceeds %d byte limit", maxCommandBytes)
-	}
-	for _, r := range command {
-		if r == '\x00' {
-			return fmt.Errorf("command contains null byte")
-		}
-	}
-	return nil
+if len(command) > maxCommandBytes {
+return fmt.Errorf("command exceeds %d byte limit", maxCommandBytes)
+}
+for _, r := range command {
+if r == '\x00' {
+return fmt.Errorf("command contains null byte")
+}
+}
+return nil
 }
 
-// Parse invokes the embedded PowerShell bridge out-of-process, feeds it the
-// command string via stdin, and unmarshals the resulting JSON into a ParsedIR.
+// ---- persistent bridge process ----
+
+// bridgeProcess holds a running pwsh bridge and its I/O handles.
+// All fields are immutable after construction except dead, which is set
+// under mu before any shutdown and never cleared.
+type bridgeProcess struct {
+mu     sync.Mutex
+cmd    *exec.Cmd
+stdin  io.WriteCloser
+stdout *bufio.Reader
+dead   bool
+}
+
+var (
+globalBridge   *bridgeProcess
+globalBridgeMu sync.Mutex
+)
+
+// getOrStartBridge returns the active bridge, starting a new one if necessary.
+func getOrStartBridge() (*bridgeProcess, error) {
+globalBridgeMu.Lock()
+defer globalBridgeMu.Unlock()
+if globalBridge != nil {
+return globalBridge, nil
+}
+bp, err := startBridgeProcess()
+if err != nil {
+return nil, err
+}
+globalBridge = bp
+return bp, nil
+}
+
+// invalidateBridge clears globalBridge if it still points to bp.
+func invalidateBridge(bp *bridgeProcess) {
+globalBridgeMu.Lock()
+if globalBridge == bp {
+globalBridge = nil
+}
+globalBridgeMu.Unlock()
+}
+
+// startBridgeProcess spawns a fresh pwsh process running the bridge loop.
+func startBridgeProcess() (*bridgeProcess, error) {
+shell := getWindowsShellPath()
+if shell == "" {
+return nil, fmt.Errorf("ast/windows: pwsh not available")
+}
+cmd := exec.Command(
+shell,
+"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+"-EncodedCommand", getBridgeEncoded(),
+)
+stdinPipe, err := cmd.StdinPipe()
+if err != nil {
+return nil, fmt.Errorf("ast/windows: stdin pipe: %w", err)
+}
+stdoutPipe, err := cmd.StdoutPipe()
+if err != nil {
+return nil, fmt.Errorf("ast/windows: stdout pipe: %w", err)
+}
+cmd.Stderr = io.Discard
+if err := cmd.Start(); err != nil {
+return nil, fmt.Errorf("ast/windows: start bridge: %w", err)
+}
+return &bridgeProcess{
+cmd:    cmd,
+stdin:  stdinPipe,
+stdout: bufio.NewReader(stdoutPipe),
+}, nil
+}
+
+const bridgeCallTimeout = 15 * time.Second
+
+// roundTrip sends one JSON request to the bridge and reads back one JSON line.
+// Must be called with bp.mu held.
+func (bp *bridgeProcess) roundTrip(command string) ([]byte, error) {
+req, err := json.Marshal(struct {
+Cmd string `json:"cmd"`
+}{Cmd: command})
+if err != nil {
+return nil, fmt.Errorf("marshal request: %w", err)
+}
+req = append(req, '\n')
+
+type result struct {
+data []byte
+err  error
+}
+ch := make(chan result, 1)
+go func() {
+if _, werr := bp.stdin.Write(req); werr != nil {
+ch <- result{nil, fmt.Errorf("write: %w", werr)}
+return
+}
+line, rerr := bp.stdout.ReadBytes('\n')
+ch <- result{bytes.TrimSpace(line), rerr}
+}()
+
+select {
+case r := <-ch:
+return r.data, r.err
+case <-time.After(bridgeCallTimeout):
+return nil, fmt.Errorf("bridge call timed out after %s", bridgeCallTimeout)
+}
+}
+
+// ---- public API ----
+
+// Parse invokes the persistent PowerShell bridge, with one automatic restart
+// attempt on transport failure.
 //
 // Fail-closed guarantee: any invocation error, transport error, or schema
 // mismatch causes a ParsedIR with ReasonSyntaxError to be returned along with
 // a non-nil error. Callers MUST treat this as requiring confirmation.
 func (w *WindowsParser) Parse(command string) (ParsedIR, error) {
-	ir := emptyIR(PlatformWindows)
+ir := emptyIR(PlatformWindows)
 
-	shell := getWindowsShellPath()
-	if shell == "" {
-		ir.ParseErrors = append(ir.ParseErrors, "pwsh/powershell not found in PATH")
-		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-		return ir, fmt.Errorf("ast/windows: pwsh not available")
-	}
+if err := sanitizeCommand(command); err != nil {
+ir.ParseErrors = append(ir.ParseErrors, err.Error())
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: %w", err)
+}
 
-	if err := sanitizeCommand(command); err != nil {
-		ir.ParseErrors = append(ir.ParseErrors, err.Error())
-		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-		return ir, fmt.Errorf("ast/windows: %w", err)
-	}
+for attempt := 0; attempt < 2; attempt++ {
+bp, err := getOrStartBridge()
+if err != nil {
+ir.ParseErrors = append(ir.ParseErrors, err.Error())
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, err
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
+bp.mu.Lock()
+if bp.dead {
+bp.mu.Unlock()
+continue
+}
+raw, callErr := bp.roundTrip(command)
+if callErr != nil {
+bp.dead = true
+bp.mu.Unlock()
+invalidateBridge(bp)
+_ = bp.cmd.Process.Kill()
+if attempt == 0 {
+continue
+}
+msg := callErr.Error()
+ir.ParseErrors = append(ir.ParseErrors, msg)
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: %s", msg)
+}
+bp.mu.Unlock()
 
-	cmd := exec.CommandContext(
-		ctx, shell,
-		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
-		"-EncodedCommand", getBridgeEncoded(),
-	)
-	cmd.Stdin = strings.NewReader(command)
+return unmarshalBridgeResponse(raw)
+}
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+// Both attempts failed (dead bridge + failed restart).
+ir.ParseErrors = append(ir.ParseErrors, "bridge unavailable after restart")
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: bridge unavailable")
+}
 
-	if err := cmd.Run(); err != nil {
-		msg := fmt.Sprintf("bridge process error: %v", err)
-		if s := strings.TrimSpace(stderr.String()); s != "" {
-			msg += ": " + s
-		}
-		ir.ParseErrors = append(ir.ParseErrors, msg)
-		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-		return ir, fmt.Errorf("ast/windows: %s", msg)
-	}
+// unmarshalBridgeResponse decodes the raw JSON line emitted by the bridge.
+func unmarshalBridgeResponse(raw []byte) (ParsedIR, error) {
+ir := emptyIR(PlatformWindows)
 
-	raw := bytes.TrimSpace(stdout.Bytes())
-	if len(raw) == 0 {
-		ir.ParseErrors = append(ir.ParseErrors, "bridge emitted empty output")
-		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-		return ir, fmt.Errorf("ast/windows: empty bridge output")
-	}
+if len(raw) == 0 {
+ir.ParseErrors = append(ir.ParseErrors, "bridge emitted empty output")
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: empty bridge output")
+}
 
-	// Unmarshal into a loose shape first to validate the version field.
-	var payload struct {
-		Version     string   `json:"version"`
-		Platform    string   `json:"platform"`
-		Commands    []string `json:"commands"`
-		Operators   []string `json:"operators"`
-		Redirects   []string `json:"redirects"`
-		Expansions  []string `json:"expansions"`
-		RiskFlags   []string `json:"risk_flags"`
-		ParseErrors []string `json:"parse_errors"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))
-		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-		return ir, fmt.Errorf("ast/windows: %w", err)
-	}
+var payload struct {
+Version     string   `json:"version"`
+Platform    string   `json:"platform"`
+Commands    []string `json:"commands"`
+Operators   []string `json:"operators"`
+Redirects   []string `json:"redirects"`
+Expansions  []string `json:"expansions"`
+RiskFlags   []string `json:"risk_flags"`
+ParseErrors []string `json:"parse_errors"`
+}
+if err := json.Unmarshal(raw, &payload); err != nil {
+ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: %w", err)
+}
 
-	// Strict schema version check — reject unknown/malformed payloads.
-	if payload.Version != IRVersion {
-		msg := fmt.Sprintf("bridge IR version mismatch: got %q, want %q", payload.Version, IRVersion)
-		ir.ParseErrors = append(ir.ParseErrors, msg)
-		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-		return ir, fmt.Errorf("ast/windows: %s", msg)
-	}
+// Strict schema version check — reject unknown/malformed payloads.
+if payload.Version != IRVersion {
+msg := fmt.Sprintf("bridge IR version mismatch: got %q, want %q", payload.Version, IRVersion)
+ir.ParseErrors = append(ir.ParseErrors, msg)
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: %s", msg)
+}
 
-	// Convert string risk flags to typed ReasonCode values, reject unknowns.
-	riskCodes := make([]ReasonCode, 0, len(payload.RiskFlags))
-	for _, rf := range payload.RiskFlags {
-		rc := ReasonCode(rf)
-		if !isKnownReasonCode(rc) {
-			ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("unknown risk flag %q from bridge", rf))
-			ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-			return ir, fmt.Errorf("ast/windows: unknown risk flag %q", rf)
-		}
-		riskCodes = appendUniqueRC(riskCodes, rc)
-	}
+// Convert string risk flags to typed ReasonCode values, reject unknowns.
+riskCodes := make([]ReasonCode, 0, len(payload.RiskFlags))
+for _, rf := range payload.RiskFlags {
+rc := ReasonCode(rf)
+if !isKnownReasonCode(rc) {
+ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("unknown risk flag %q from bridge", rf))
+ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+return ir, fmt.Errorf("ast/windows: unknown risk flag %q", rf)
+}
+riskCodes = appendUniqueRC(riskCodes, rc)
+}
 
-	// Populate final IR — all slices guaranteed non-nil by emptyIR.
-	ir.Commands = nilToEmpty(payload.Commands)
-	ir.Operators = nilToEmpty(payload.Operators)
-	ir.Redirects = nilToEmpty(payload.Redirects)
-	ir.Expansions = nilToEmpty(payload.Expansions)
-	ir.RiskFlags = riskCodes
-	ir.ParseErrors = nilToEmpty(payload.ParseErrors)
+ir.Commands = nilToEmpty(payload.Commands)
+ir.Operators = nilToEmpty(payload.Operators)
+ir.Redirects = nilToEmpty(payload.Redirects)
+ir.Expansions = nilToEmpty(payload.Expansions)
+ir.RiskFlags = riskCodes
+ir.ParseErrors = nilToEmpty(payload.ParseErrors)
 
-	return ir, nil
+return ir, nil
 }
 
 func nilToEmpty(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
+if s == nil {
+return []string{}
+}
+return s
 }
 
 // isKnownReasonCode validates that rc is one of the defined ReasonCode constants.
 func isKnownReasonCode(rc ReasonCode) bool {
-	switch rc {
-	case ReasonOperator, ReasonRedirect, ReasonExpansion, ReasonSubshell,
-		ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath:
-		return true
-	}
-	return false
+switch rc {
+case ReasonOperator, ReasonRedirect, ReasonExpansion, ReasonSubshell,
+ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath:
+return true
+}
+return false
 }

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -200,7 +200,7 @@ func nilToEmpty(s []string) []string {
 func isKnownReasonCode(rc ReasonCode) bool {
 	switch rc {
 	case ReasonOperator, ReasonRedirect, ReasonExpansion, ReasonSubshell,
-		ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath, ReasonAllowlisted:
+		ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath:
 		return true
 	}
 	return false

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -1,0 +1,174 @@
+package ast
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf16"
+	"encoding/base64"
+)
+
+//go:embed ps_bridge.ps1
+var psBridgeScript []byte
+
+// WindowsParser implements Parser for PowerShell using an out-of-process pwsh
+// bridge that invokes System.Management.Automation.Language.Parser::ParseInput.
+// The bridge NEVER executes the command; it only parses and emits JSON IR.
+//
+// On non-Windows hosts (or when pwsh is unavailable) Parse fails closed:
+// it returns a ParsedIR with ReasonSyntaxError and a non-nil error.
+type WindowsParser struct {
+	// Cwd is the working directory context used for path-resolution heuristics
+	// in the policy engine. The bridge script itself does not use it.
+	Cwd string
+}
+
+var (
+	winPSPath     string
+	winPSPathOnce sync.Once
+)
+
+func getWindowsShellPath() string {
+	winPSPathOnce.Do(func() {
+		if p, err := exec.LookPath("pwsh.exe"); err == nil {
+			winPSPath = p
+			return
+		}
+		if p, err := exec.LookPath("powershell.exe"); err == nil {
+			winPSPath = p
+			return
+		}
+		winPSPath = ""
+	})
+	return winPSPath
+}
+
+// encodePSScript base64-encodes a PowerShell script for -EncodedCommand.
+func encodePSScript(script []byte) string {
+	u16 := utf16.Encode([]rune(string(script)))
+	b := make([]byte, len(u16)*2)
+	for i, r := range u16 {
+		b[i*2] = byte(r)
+		b[i*2+1] = byte(r >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// Parse invokes the embedded PowerShell bridge out-of-process, feeds it the
+// command string via stdin, and unmarshals the resulting JSON into a ParsedIR.
+//
+// Fail-closed guarantee: any invocation error, transport error, or schema
+// mismatch causes a ParsedIR with ReasonSyntaxError to be returned along with
+// a non-nil error. Callers MUST treat this as requiring confirmation.
+func (w *WindowsParser) Parse(command string) (ParsedIR, error) {
+	ir := emptyIR(PlatformWindows)
+
+	shell := getWindowsShellPath()
+	if shell == "" {
+		ir.ParseErrors = append(ir.ParseErrors, "pwsh/powershell not found in PATH")
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: pwsh not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	encoded := encodePSScript(psBridgeScript)
+	cmd := exec.CommandContext(
+		ctx, shell,
+		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-EncodedCommand", encoded,
+	)
+	cmd.Stdin = strings.NewReader(command)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := fmt.Sprintf("bridge process error: %v", err)
+		if s := strings.TrimSpace(stderr.String()); s != "" {
+			msg += ": " + s
+		}
+		ir.ParseErrors = append(ir.ParseErrors, msg)
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %s", msg)
+	}
+
+	raw := bytes.TrimSpace(stdout.Bytes())
+	if len(raw) == 0 {
+		ir.ParseErrors = append(ir.ParseErrors, "bridge emitted empty output")
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: empty bridge output")
+	}
+
+	// Unmarshal into a loose shape first to validate the version field.
+	var payload struct {
+		Version     string       `json:"version"`
+		Platform    string       `json:"platform"`
+		Commands    []string     `json:"commands"`
+		Operators   []string     `json:"operators"`
+		Redirects   []string     `json:"redirects"`
+		Expansions  []string     `json:"expansions"`
+		RiskFlags   []string     `json:"risk_flags"`
+		ParseErrors []string     `json:"parse_errors"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %w", err)
+	}
+
+	// Strict schema version check — reject unknown/malformed payloads.
+	if payload.Version != IRVersion {
+		msg := fmt.Sprintf("bridge IR version mismatch: got %q, want %q", payload.Version, IRVersion)
+		ir.ParseErrors = append(ir.ParseErrors, msg)
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %s", msg)
+	}
+
+	// Convert string risk flags to typed ReasonCode values, reject unknowns.
+	riskCodes := make([]ReasonCode, 0, len(payload.RiskFlags))
+	for _, rf := range payload.RiskFlags {
+		rc := ReasonCode(rf)
+		if !isKnownReasonCode(rc) {
+			ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("unknown risk flag %q from bridge", rf))
+			ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+			return ir, fmt.Errorf("ast/windows: unknown risk flag %q", rf)
+		}
+		riskCodes = appendUniqueRC(riskCodes, rc)
+	}
+
+	// Populate final IR — all slices guaranteed non-nil by emptyIR.
+	ir.Commands = nilToEmpty(payload.Commands)
+	ir.Operators = nilToEmpty(payload.Operators)
+	ir.Redirects = nilToEmpty(payload.Redirects)
+	ir.Expansions = nilToEmpty(payload.Expansions)
+	ir.RiskFlags = riskCodes
+	ir.ParseErrors = nilToEmpty(payload.ParseErrors)
+
+	return ir, nil
+}
+
+func nilToEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+// isKnownReasonCode validates that rc is one of the defined ReasonCode constants.
+func isKnownReasonCode(rc ReasonCode) bool {
+	switch rc {
+	case ReasonOperator, ReasonRedirect, ReasonExpansion, ReasonSubshell,
+		ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath, ReasonAllowlisted:
+		return true
+	}
+	return false
+}

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -11,7 +12,6 @@ import (
 	"sync"
 	"time"
 	"unicode/utf16"
-	"encoding/base64"
 )
 
 //go:embed ps_bridge.ps1
@@ -32,6 +32,9 @@ type WindowsParser struct {
 var (
 	winPSPath     string
 	winPSPathOnce sync.Once
+
+	winEncodedBridge     string
+	winEncodedBridgeOnce sync.Once
 )
 
 func getWindowsShellPath() string {
@@ -60,6 +63,31 @@ func encodePSScript(script []byte) string {
 	return base64.StdEncoding.EncodeToString(b)
 }
 
+// getBridgeEncoded returns the cached base64-encoded bridge script.
+func getBridgeEncoded() string {
+	winEncodedBridgeOnce.Do(func() {
+		winEncodedBridge = encodePSScript(psBridgeScript)
+	})
+	return winEncodedBridge
+}
+
+const maxCommandBytes = 65536
+
+// sanitizeCommand rejects inputs that could corrupt the bridge transport:
+// null bytes, carriage-return-only line endings that survive the PS stdin
+// reader, or commands exceeding the size guard.
+func sanitizeCommand(command string) error {
+	if len(command) > maxCommandBytes {
+		return fmt.Errorf("command exceeds %d byte limit", maxCommandBytes)
+	}
+	for _, r := range command {
+		if r == '\x00' {
+			return fmt.Errorf("command contains null byte")
+		}
+	}
+	return nil
+}
+
 // Parse invokes the embedded PowerShell bridge out-of-process, feeds it the
 // command string via stdin, and unmarshals the resulting JSON into a ParsedIR.
 //
@@ -76,14 +104,19 @@ func (w *WindowsParser) Parse(command string) (ParsedIR, error) {
 		return ir, fmt.Errorf("ast/windows: pwsh not available")
 	}
 
+	if err := sanitizeCommand(command); err != nil {
+		ir.ParseErrors = append(ir.ParseErrors, err.Error())
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %w", err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	encoded := encodePSScript(psBridgeScript)
 	cmd := exec.CommandContext(
 		ctx, shell,
 		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
-		"-EncodedCommand", encoded,
+		"-EncodedCommand", getBridgeEncoded(),
 	)
 	cmd.Stdin = strings.NewReader(command)
 
@@ -110,14 +143,14 @@ func (w *WindowsParser) Parse(command string) (ParsedIR, error) {
 
 	// Unmarshal into a loose shape first to validate the version field.
 	var payload struct {
-		Version     string       `json:"version"`
-		Platform    string       `json:"platform"`
-		Commands    []string     `json:"commands"`
-		Operators   []string     `json:"operators"`
-		Redirects   []string     `json:"redirects"`
-		Expansions  []string     `json:"expansions"`
-		RiskFlags   []string     `json:"risk_flags"`
-		ParseErrors []string     `json:"parse_errors"`
+		Version     string   `json:"version"`
+		Platform    string   `json:"platform"`
+		Commands    []string `json:"commands"`
+		Operators   []string `json:"operators"`
+		Redirects   []string `json:"redirects"`
+		Expansions  []string `json:"expansions"`
+		RiskFlags   []string `json:"risk_flags"`
+		ParseErrors []string `json:"parse_errors"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -192,6 +192,7 @@ func startBridgeProcess() (*bridgeProcess, error) {
 	cmd.Stderr = io.Discard
 	if err := cmd.Start(); err != nil {
 		_ = stdinPipe.Close()
+		_ = stdoutPipe.Close()
 		return nil, fmt.Errorf("ast/windows: start bridge: %w", err)
 	}
 	return &bridgeProcess{
@@ -269,6 +270,10 @@ func (w *WindowsParser) Parse(command string) (ParsedIR, error) {
 		bp.mu.Lock()
 		if bp.dead {
 			bp.mu.Unlock()
+			// Ensure the global pointer is cleared so the next getOrStartBridge()
+			// starts a fresh process rather than handing out the dead bridge again.
+			invalidateBridge(bp)
+			go bp.shutdown()
 			continue
 		}
 		raw, callErr := bp.roundTrip(command)
@@ -326,6 +331,14 @@ func unmarshalBridgeResponse(raw []byte) (ParsedIR, error) {
 	// Strict schema version check — reject unknown/malformed payloads.
 	if payload.Version != IRVersion {
 		msg := fmt.Sprintf("bridge IR version mismatch: got %q, want %q", payload.Version, IRVersion)
+		ir.ParseErrors = append(ir.ParseErrors, msg)
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %s", msg)
+	}
+
+	// Strict platform check — reject payloads not intended for the Windows adapter.
+	if payload.Platform != string(PlatformWindows) {
+		msg := fmt.Sprintf("bridge platform mismatch: got %q, want %q", payload.Platform, string(PlatformWindows))
 		ir.ParseErrors = append(ir.ParseErrors, msg)
 		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
 		return ir, fmt.Errorf("ast/windows: %s", msg)

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -313,14 +313,15 @@ func unmarshalBridgeResponse(raw []byte) (ParsedIR, error) {
 	}
 
 	var payload struct {
-		Version     string   `json:"version"`
-		Platform    string   `json:"platform"`
-		Commands    []string `json:"commands"`
-		Operators   []string `json:"operators"`
-		Redirects   []string `json:"redirects"`
-		Expansions  []string `json:"expansions"`
-		RiskFlags   []string `json:"risk_flags"`
-		ParseErrors []string `json:"parse_errors"`
+		Version     string              `json:"version"`
+		Platform    string              `json:"platform"`
+		Commands    []string            `json:"commands"`
+		Operators   []string            `json:"operators"`
+		Redirects   []string            `json:"redirects"`
+		Expansions  []string            `json:"expansions"`
+		RiskFlags   []string            `json:"risk_flags"`
+		ParseErrors []string            `json:"parse_errors"`
+		CommandArgs map[string][]string `json:"command_args"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))
@@ -362,6 +363,7 @@ func unmarshalBridgeResponse(raw []byte) (ParsedIR, error) {
 	ir.Expansions = nilToEmpty(payload.Expansions)
 	ir.RiskFlags = riskCodes
 	ir.ParseErrors = nilToEmpty(payload.ParseErrors)
+	ir.CommandArgs = nilToEmptyMap(payload.CommandArgs)
 
 	return ir, nil
 }
@@ -371,6 +373,13 @@ func nilToEmpty(s []string) []string {
 		return []string{}
 	}
 	return s
+}
+
+func nilToEmptyMap(m map[string][]string) map[string][]string {
+	if m == nil {
+		return map[string][]string{}
+	}
+	return m
 }
 
 // isKnownReasonCode validates that rc is one of the defined ReasonCode constants.

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -186,10 +186,12 @@ func startBridgeProcess() (*bridgeProcess, error) {
 	}
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
+		_ = stdinPipe.Close()
 		return nil, fmt.Errorf("ast/windows: stdout pipe: %w", err)
 	}
 	cmd.Stderr = io.Discard
 	if err := cmd.Start(); err != nil {
+		_ = stdinPipe.Close()
 		return nil, fmt.Errorf("ast/windows: start bridge: %w", err)
 	}
 	return &bridgeProcess{
@@ -230,9 +232,10 @@ func (bp *bridgeProcess) roundTrip(command string) ([]byte, error) {
 	case r := <-ch:
 		return r.data, r.err
 	case <-time.After(bridgeCallTimeout):
-		// Close stdin to unblock the I/O goroutine immediately: the Write will
-		// fail and the bridge loop will see EOF.  The goroutine always sends to
-		// the buffered channel and exits; no goroutine leak.
+		// Close stdin so the bridge loop sees EOF and exits.  The I/O goroutine
+		// unblocks once the bridge process terminates (or when the subsequent
+		// shutdown() call force-kills it).  The goroutine always sends to the
+		// buffered channel and exits cleanly; no goroutine leak.
 		_ = bp.stdin.Close()
 		return nil, fmt.Errorf("bridge call timed out after %s", bridgeCallTimeout)
 	}

--- a/internal/tool/ast/windows_adapter.go
+++ b/internal/tool/ast/windows_adapter.go
@@ -1,11 +1,11 @@
 package ast
 
 import (
-"bufio"
-"bytes"
-_ "embed"
-"encoding/base64"
-"encoding/json"
+	"bufio"
+	"bytes"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -27,51 +27,51 @@ var psBridgeScript []byte
 // On non-Windows hosts (or when pwsh is unavailable) Parse fails closed:
 // it returns a ParsedIR with ReasonSyntaxError and a non-nil error.
 type WindowsParser struct {
-// Cwd is the working directory context used for path-resolution heuristics
-// in the policy engine. The bridge script itself does not use it.
-Cwd string
+	// Cwd is the working directory context used for path-resolution heuristics
+	// in the policy engine. The bridge script itself does not use it.
+	Cwd string
 }
 
 var (
-winPSPath     string
-winPSPathOnce sync.Once
+	winPSPath     string
+	winPSPathOnce sync.Once
 
-winEncodedBridge     string
-winEncodedBridgeOnce sync.Once
+	winEncodedBridge     string
+	winEncodedBridgeOnce sync.Once
 )
 
 func getWindowsShellPath() string {
-winPSPathOnce.Do(func() {
-if p, err := exec.LookPath("pwsh.exe"); err == nil {
-winPSPath = p
-return
-}
-if p, err := exec.LookPath("powershell.exe"); err == nil {
-winPSPath = p
-return
-}
-winPSPath = ""
-})
-return winPSPath
+	winPSPathOnce.Do(func() {
+		if p, err := exec.LookPath("pwsh.exe"); err == nil {
+			winPSPath = p
+			return
+		}
+		if p, err := exec.LookPath("powershell.exe"); err == nil {
+			winPSPath = p
+			return
+		}
+		winPSPath = ""
+	})
+	return winPSPath
 }
 
 // encodePSScript base64-encodes a PowerShell script for -EncodedCommand.
 func encodePSScript(script []byte) string {
-u16 := utf16.Encode([]rune(string(script)))
-b := make([]byte, len(u16)*2)
-for i, r := range u16 {
-b[i*2] = byte(r)
-b[i*2+1] = byte(r >> 8)
-}
-return base64.StdEncoding.EncodeToString(b)
+	u16 := utf16.Encode([]rune(string(script)))
+	b := make([]byte, len(u16)*2)
+	for i, r := range u16 {
+		b[i*2] = byte(r)
+		b[i*2+1] = byte(r >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(b)
 }
 
 // getBridgeEncoded returns the cached base64-encoded bridge script.
 func getBridgeEncoded() string {
-winEncodedBridgeOnce.Do(func() {
-winEncodedBridge = encodePSScript(psBridgeScript)
-})
-return winEncodedBridge
+	winEncodedBridgeOnce.Do(func() {
+		winEncodedBridge = encodePSScript(psBridgeScript)
+	})
+	return winEncodedBridge
 }
 
 const maxCommandBytes = 65536
@@ -79,15 +79,15 @@ const maxCommandBytes = 65536
 // sanitizeCommand rejects inputs that could corrupt the bridge transport:
 // null bytes or commands exceeding the size guard.
 func sanitizeCommand(command string) error {
-if len(command) > maxCommandBytes {
-return fmt.Errorf("command exceeds %d byte limit", maxCommandBytes)
-}
-for _, r := range command {
-if r == '\x00' {
-return fmt.Errorf("command contains null byte")
-}
-}
-return nil
+	if len(command) > maxCommandBytes {
+		return fmt.Errorf("command exceeds %d byte limit", maxCommandBytes)
+	}
+	for _, r := range command {
+		if r == '\x00' {
+			return fmt.Errorf("command contains null byte")
+		}
+	}
+	return nil
 }
 
 // ---- persistent bridge process ----
@@ -96,70 +96,107 @@ return nil
 // All fields are immutable after construction except dead, which is set
 // under mu before any shutdown and never cleared.
 type bridgeProcess struct {
-mu     sync.Mutex
-cmd    *exec.Cmd
-stdin  io.WriteCloser
-stdout *bufio.Reader
-dead   bool
+	mu     sync.Mutex
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	dead   bool
+}
+
+// shutdown terminates the bridge process.  It closes stdin so the bridge loop
+// sees EOF and exits cleanly, then waits for the process to finish.  If the
+// process does not exit within 2 s it is forcibly killed.
+//
+// Note: on Windows, if the Go process itself crashes (panic, os.Exit), the
+// bridge process will be orphaned because Windows has no equivalent of
+// SIGKILL-on-parent-exit.  A proper fix requires associating the child with a
+// Windows Job Object (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE), which would need
+// golang.org/x/sys/windows.  For now this is an accepted limitation.
+func (bp *bridgeProcess) shutdown() {
+	_ = bp.stdin.Close()
+	done := make(chan struct{})
+	go func() {
+		_ = bp.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		_ = bp.cmd.Process.Kill()
+		<-done
+	}
 }
 
 var (
-globalBridge   *bridgeProcess
-globalBridgeMu sync.Mutex
+	globalBridge   *bridgeProcess
+	globalBridgeMu sync.Mutex
 )
 
 // getOrStartBridge returns the active bridge, starting a new one if necessary.
 func getOrStartBridge() (*bridgeProcess, error) {
-globalBridgeMu.Lock()
-defer globalBridgeMu.Unlock()
-if globalBridge != nil {
-return globalBridge, nil
-}
-bp, err := startBridgeProcess()
-if err != nil {
-return nil, err
-}
-globalBridge = bp
-return bp, nil
+	globalBridgeMu.Lock()
+	defer globalBridgeMu.Unlock()
+	if globalBridge != nil {
+		return globalBridge, nil
+	}
+	bp, err := startBridgeProcess()
+	if err != nil {
+		return nil, err
+	}
+	globalBridge = bp
+	return bp, nil
 }
 
 // invalidateBridge clears globalBridge if it still points to bp.
 func invalidateBridge(bp *bridgeProcess) {
-globalBridgeMu.Lock()
-if globalBridge == bp {
-globalBridge = nil
+	globalBridgeMu.Lock()
+	if globalBridge == bp {
+		globalBridge = nil
+	}
+	globalBridgeMu.Unlock()
 }
-globalBridgeMu.Unlock()
+
+// CloseBridge shuts down the global bridge process if one is running.
+// Subsequent Parse calls will start a fresh bridge.  Safe to call multiple times.
+// Useful for testing and for explicit resource cleanup on process exit.
+func CloseBridge() {
+	globalBridgeMu.Lock()
+	bp := globalBridge
+	globalBridge = nil
+	globalBridgeMu.Unlock()
+	if bp != nil {
+		bp.shutdown()
+	}
 }
 
 // startBridgeProcess spawns a fresh pwsh process running the bridge loop.
 func startBridgeProcess() (*bridgeProcess, error) {
-shell := getWindowsShellPath()
-if shell == "" {
-return nil, fmt.Errorf("ast/windows: pwsh not available")
-}
-cmd := exec.Command(
-shell,
-"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
-"-EncodedCommand", getBridgeEncoded(),
-)
-stdinPipe, err := cmd.StdinPipe()
-if err != nil {
-return nil, fmt.Errorf("ast/windows: stdin pipe: %w", err)
-}
-stdoutPipe, err := cmd.StdoutPipe()
-if err != nil {
-return nil, fmt.Errorf("ast/windows: stdout pipe: %w", err)
-}
-cmd.Stderr = io.Discard
-if err := cmd.Start(); err != nil {
-return nil, fmt.Errorf("ast/windows: start bridge: %w", err)
-}
-return &bridgeProcess{
-cmd:    cmd,
-stdin:  stdinPipe,
-stdout: bufio.NewReader(stdoutPipe),
-}, nil
+	shell := getWindowsShellPath()
+	if shell == "" {
+		return nil, fmt.Errorf("ast/windows: pwsh not available")
+	}
+	cmd := exec.Command(
+		shell,
+		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-EncodedCommand", getBridgeEncoded(),
+	)
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("ast/windows: stdin pipe: %w", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("ast/windows: stdout pipe: %w", err)
+	}
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("ast/windows: start bridge: %w", err)
+	}
+	return &bridgeProcess{
+		cmd:    cmd,
+		stdin:  stdinPipe,
+		stdout: bufio.NewReader(stdoutPipe),
+	}, nil
 }
 
 const bridgeCallTimeout = 15 * time.Second
@@ -167,34 +204,38 @@ const bridgeCallTimeout = 15 * time.Second
 // roundTrip sends one JSON request to the bridge and reads back one JSON line.
 // Must be called with bp.mu held.
 func (bp *bridgeProcess) roundTrip(command string) ([]byte, error) {
-req, err := json.Marshal(struct {
-Cmd string `json:"cmd"`
-}{Cmd: command})
-if err != nil {
-return nil, fmt.Errorf("marshal request: %w", err)
-}
-req = append(req, '\n')
+	req, err := json.Marshal(struct {
+		Cmd string `json:"cmd"`
+	}{Cmd: command})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req = append(req, '\n')
 
-type result struct {
-data []byte
-err  error
-}
-ch := make(chan result, 1)
-go func() {
-if _, werr := bp.stdin.Write(req); werr != nil {
-ch <- result{nil, fmt.Errorf("write: %w", werr)}
-return
-}
-line, rerr := bp.stdout.ReadBytes('\n')
-ch <- result{bytes.TrimSpace(line), rerr}
-}()
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		if _, werr := bp.stdin.Write(req); werr != nil {
+			ch <- result{nil, fmt.Errorf("write: %w", werr)}
+			return
+		}
+		line, rerr := bp.stdout.ReadBytes('\n')
+		ch <- result{bytes.TrimSpace(line), rerr}
+	}()
 
-select {
-case r := <-ch:
-return r.data, r.err
-case <-time.After(bridgeCallTimeout):
-return nil, fmt.Errorf("bridge call timed out after %s", bridgeCallTimeout)
-}
+	select {
+	case r := <-ch:
+		return r.data, r.err
+	case <-time.After(bridgeCallTimeout):
+		// Close stdin to unblock the I/O goroutine immediately: the Write will
+		// fail and the bridge loop will see EOF.  The goroutine always sends to
+		// the buffered channel and exits; no goroutine leak.
+		_ = bp.stdin.Close()
+		return nil, fmt.Errorf("bridge call timed out after %s", bridgeCallTimeout)
+	}
 }
 
 // ---- public API ----
@@ -206,121 +247,122 @@ return nil, fmt.Errorf("bridge call timed out after %s", bridgeCallTimeout)
 // mismatch causes a ParsedIR with ReasonSyntaxError to be returned along with
 // a non-nil error. Callers MUST treat this as requiring confirmation.
 func (w *WindowsParser) Parse(command string) (ParsedIR, error) {
-ir := emptyIR(PlatformWindows)
+	ir := emptyIR(PlatformWindows)
 
-if err := sanitizeCommand(command); err != nil {
-ir.ParseErrors = append(ir.ParseErrors, err.Error())
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: %w", err)
-}
+	if err := sanitizeCommand(command); err != nil {
+		ir.ParseErrors = append(ir.ParseErrors, err.Error())
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %w", err)
+	}
 
-for attempt := 0; attempt < 2; attempt++ {
-bp, err := getOrStartBridge()
-if err != nil {
-ir.ParseErrors = append(ir.ParseErrors, err.Error())
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, err
-}
+	for attempt := 0; attempt < 2; attempt++ {
+		bp, err := getOrStartBridge()
+		if err != nil {
+			ir.ParseErrors = append(ir.ParseErrors, err.Error())
+			ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+			return ir, err
+		}
 
-bp.mu.Lock()
-if bp.dead {
-bp.mu.Unlock()
-continue
-}
-raw, callErr := bp.roundTrip(command)
-if callErr != nil {
-bp.dead = true
-bp.mu.Unlock()
-invalidateBridge(bp)
-_ = bp.cmd.Process.Kill()
-if attempt == 0 {
-continue
-}
-msg := callErr.Error()
-ir.ParseErrors = append(ir.ParseErrors, msg)
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: %s", msg)
-}
-bp.mu.Unlock()
+		bp.mu.Lock()
+		if bp.dead {
+			bp.mu.Unlock()
+			continue
+		}
+		raw, callErr := bp.roundTrip(command)
+		if callErr != nil {
+			bp.dead = true
+			bp.mu.Unlock()
+			invalidateBridge(bp)
+			// Shutdown asynchronously so the retry can start a new bridge immediately.
+			go bp.shutdown()
+			if attempt == 0 {
+				continue
+			}
+			msg := callErr.Error()
+			ir.ParseErrors = append(ir.ParseErrors, msg)
+			ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+			return ir, fmt.Errorf("ast/windows: %s", msg)
+		}
+		bp.mu.Unlock()
 
-return unmarshalBridgeResponse(raw)
-}
+		return unmarshalBridgeResponse(raw)
+	}
 
-// Both attempts failed (dead bridge + failed restart).
-ir.ParseErrors = append(ir.ParseErrors, "bridge unavailable after restart")
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: bridge unavailable")
+	// Both attempts failed (dead bridge + failed restart).
+	ir.ParseErrors = append(ir.ParseErrors, "bridge unavailable after restart")
+	ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+	return ir, fmt.Errorf("ast/windows: bridge unavailable")
 }
 
 // unmarshalBridgeResponse decodes the raw JSON line emitted by the bridge.
 func unmarshalBridgeResponse(raw []byte) (ParsedIR, error) {
-ir := emptyIR(PlatformWindows)
+	ir := emptyIR(PlatformWindows)
 
-if len(raw) == 0 {
-ir.ParseErrors = append(ir.ParseErrors, "bridge emitted empty output")
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: empty bridge output")
-}
+	if len(raw) == 0 {
+		ir.ParseErrors = append(ir.ParseErrors, "bridge emitted empty output")
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: empty bridge output")
+	}
 
-var payload struct {
-Version     string   `json:"version"`
-Platform    string   `json:"platform"`
-Commands    []string `json:"commands"`
-Operators   []string `json:"operators"`
-Redirects   []string `json:"redirects"`
-Expansions  []string `json:"expansions"`
-RiskFlags   []string `json:"risk_flags"`
-ParseErrors []string `json:"parse_errors"`
-}
-if err := json.Unmarshal(raw, &payload); err != nil {
-ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: %w", err)
-}
+	var payload struct {
+		Version     string   `json:"version"`
+		Platform    string   `json:"platform"`
+		Commands    []string `json:"commands"`
+		Operators   []string `json:"operators"`
+		Redirects   []string `json:"redirects"`
+		Expansions  []string `json:"expansions"`
+		RiskFlags   []string `json:"risk_flags"`
+		ParseErrors []string `json:"parse_errors"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("bridge JSON decode error: %v", err))
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %w", err)
+	}
 
-// Strict schema version check — reject unknown/malformed payloads.
-if payload.Version != IRVersion {
-msg := fmt.Sprintf("bridge IR version mismatch: got %q, want %q", payload.Version, IRVersion)
-ir.ParseErrors = append(ir.ParseErrors, msg)
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: %s", msg)
-}
+	// Strict schema version check — reject unknown/malformed payloads.
+	if payload.Version != IRVersion {
+		msg := fmt.Sprintf("bridge IR version mismatch: got %q, want %q", payload.Version, IRVersion)
+		ir.ParseErrors = append(ir.ParseErrors, msg)
+		ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+		return ir, fmt.Errorf("ast/windows: %s", msg)
+	}
 
-// Convert string risk flags to typed ReasonCode values, reject unknowns.
-riskCodes := make([]ReasonCode, 0, len(payload.RiskFlags))
-for _, rf := range payload.RiskFlags {
-rc := ReasonCode(rf)
-if !isKnownReasonCode(rc) {
-ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("unknown risk flag %q from bridge", rf))
-ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
-return ir, fmt.Errorf("ast/windows: unknown risk flag %q", rf)
-}
-riskCodes = appendUniqueRC(riskCodes, rc)
-}
+	// Convert string risk flags to typed ReasonCode values, reject unknowns.
+	riskCodes := make([]ReasonCode, 0, len(payload.RiskFlags))
+	for _, rf := range payload.RiskFlags {
+		rc := ReasonCode(rf)
+		if !isKnownReasonCode(rc) {
+			ir.ParseErrors = append(ir.ParseErrors, fmt.Sprintf("unknown risk flag %q from bridge", rf))
+			ir.RiskFlags = appendUniqueRC(ir.RiskFlags, ReasonSyntaxError)
+			return ir, fmt.Errorf("ast/windows: unknown risk flag %q", rf)
+		}
+		riskCodes = appendUniqueRC(riskCodes, rc)
+	}
 
-ir.Commands = nilToEmpty(payload.Commands)
-ir.Operators = nilToEmpty(payload.Operators)
-ir.Redirects = nilToEmpty(payload.Redirects)
-ir.Expansions = nilToEmpty(payload.Expansions)
-ir.RiskFlags = riskCodes
-ir.ParseErrors = nilToEmpty(payload.ParseErrors)
+	ir.Commands = nilToEmpty(payload.Commands)
+	ir.Operators = nilToEmpty(payload.Operators)
+	ir.Redirects = nilToEmpty(payload.Redirects)
+	ir.Expansions = nilToEmpty(payload.Expansions)
+	ir.RiskFlags = riskCodes
+	ir.ParseErrors = nilToEmpty(payload.ParseErrors)
 
-return ir, nil
+	return ir, nil
 }
 
 func nilToEmpty(s []string) []string {
-if s == nil {
-return []string{}
-}
-return s
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 // isKnownReasonCode validates that rc is one of the defined ReasonCode constants.
 func isKnownReasonCode(rc ReasonCode) bool {
-switch rc {
-case ReasonOperator, ReasonRedirect, ReasonExpansion, ReasonSubshell,
-ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath:
-return true
-}
-return false
+	switch rc {
+	case ReasonOperator, ReasonRedirect, ReasonExpansion, ReasonSubshell,
+		ReasonInvokeExpr, ReasonCd, ReasonSyntaxError, ReasonNewPath, ReasonDestructive:
+		return true
+	}
+	return false
 }

--- a/internal/tool/ast/windows_adapter_test.go
+++ b/internal/tool/ast/windows_adapter_test.go
@@ -1,0 +1,123 @@
+//go:build windows
+
+package ast
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestWindowsParser_BridgeContract verifies the JSON schema contract of the
+// PowerShell bridge script. It skips when pwsh is unavailable (CI without PS).
+func TestWindowsParser_BridgeContract(t *testing.T) {
+	if _, err := exec.LookPath("pwsh.exe"); err != nil {
+		if _, err2 := exec.LookPath("powershell.exe"); err2 != nil {
+			t.Skip("pwsh/powershell not available")
+		}
+	}
+
+	p := &WindowsParser{}
+	tests := []struct {
+		command     string
+		wantCmds    []string
+		wantRisk    []ReasonCode
+		noRisk      []ReasonCode
+	}{
+		{
+			command:  "Get-ChildItem",
+			wantCmds: []string{"get-childitem"},
+			noRisk:   []ReasonCode{ReasonRedirect, ReasonSubshell, ReasonInvokeExpr},
+		},
+		{
+			command:  "Get-ChildItem | Select-String foo",
+			wantCmds: []string{"get-childitem", "select-string"},
+			wantRisk: []ReasonCode{ReasonOperator},
+		},
+		{
+			command:  "Get-Date; Get-Location",
+			wantRisk: []ReasonCode{ReasonOperator},
+		},
+		{
+			command:  "Invoke-Expression 'rm -rf /'",
+			wantRisk: []ReasonCode{ReasonInvokeExpr},
+		},
+		{
+			command:  "$x = 'foo'; Write-Output $x",
+			wantRisk: []ReasonCode{ReasonExpansion},
+		},
+		{
+			command:  "Get-ChildItem > out.txt",
+			wantRisk: []ReasonCode{ReasonRedirect},
+		},
+		{
+			command:  "Write-Output $(Get-Date)",
+			wantRisk: []ReasonCode{ReasonSubshell},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.command, func(t *testing.T) {
+			ir, err := p.Parse(tc.command)
+			// Bridge errors are allowed for problematic syntax but must produce a valid IR.
+			_ = err
+
+			if ir.Version != IRVersion {
+				t.Errorf("Version: got %q want %q", ir.Version, IRVersion)
+			}
+			if ir.Platform != PlatformWindows {
+				t.Errorf("Platform: got %q want %q", ir.Platform, PlatformWindows)
+			}
+
+			for _, wantCmd := range tc.wantCmds {
+				found := false
+				for _, c := range ir.Commands {
+					if strings.EqualFold(c, wantCmd) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected command %q in %v", wantCmd, ir.Commands)
+				}
+			}
+
+			for _, wantRC := range tc.wantRisk {
+				if !hasRisk(ir, wantRC) {
+					t.Errorf("expected risk flag %q in %v", wantRC, ir.RiskFlags)
+				}
+			}
+
+			for _, noRC := range tc.noRisk {
+				if hasRisk(ir, noRC) {
+					t.Errorf("unexpected risk flag %q in %v", noRC, ir.RiskFlags)
+				}
+			}
+		})
+	}
+}
+
+// TestWindowsParser_FailClosed ensures the adapter fails safely when pwsh is
+// absent or the bridge emits garbage.
+func TestWindowsParser_FailClosed(t *testing.T) {
+	// Simulate unavailable shell by using an empty path override in a test-only way.
+	// We can't easily do this without the sync.Once, so just check the IR contract
+	// on a real parse with a clearly broken input.
+	if _, err := exec.LookPath("pwsh.exe"); err != nil {
+		if _, err2 := exec.LookPath("powershell.exe"); err2 != nil {
+			t.Skip("pwsh/powershell not available")
+		}
+	}
+
+	p := &WindowsParser{}
+	// Malformed input — PS parser should still emit something but we verify
+	// the Go layer never panics and returns a usable IR.
+	ir, _ := p.Parse("if (")
+
+	if ir.Version != IRVersion {
+		t.Errorf("Version must be set even on parse error, got %q", ir.Version)
+	}
+	if ir.Platform != PlatformWindows {
+		t.Errorf("Platform must be set even on parse error")
+	}
+}

--- a/internal/tool/ast/windows_adapter_test.go
+++ b/internal/tool/ast/windows_adapter_test.go
@@ -5,17 +5,23 @@ package ast
 import (
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 )
 
-// TestWindowsParser_BridgeContract verifies the JSON schema contract of the
-// PowerShell bridge script. It skips when pwsh is unavailable (CI without PS).
-func TestWindowsParser_BridgeContract(t *testing.T) {
+func skipIfNoPwsh(t *testing.T) {
+	t.Helper()
 	if _, err := exec.LookPath("pwsh.exe"); err != nil {
 		if _, err2 := exec.LookPath("powershell.exe"); err2 != nil {
 			t.Skip("pwsh/powershell not available")
 		}
 	}
+}
+
+// TestWindowsParser_BridgeContract verifies the JSON schema contract of the
+// PowerShell bridge script for a representative set of command patterns.
+func TestWindowsParser_BridgeContract(t *testing.T) {
+	skipIfNoPwsh(t)
 
 	p := &WindowsParser{}
 	tests := []struct {
@@ -27,7 +33,7 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 		{
 			command:  "Get-ChildItem",
 			wantCmds: []string{"get-childitem"},
-			noRisk:   []ReasonCode{ReasonRedirect, ReasonSubshell, ReasonInvokeExpr},
+			noRisk:   []ReasonCode{ReasonRedirect, ReasonSubshell, ReasonInvokeExpr, ReasonDestructive},
 		},
 		{
 			command:  "Get-ChildItem | Select-String foo",
@@ -41,6 +47,7 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 		{
 			command:  "Invoke-Expression 'rm -rf /'",
 			wantRisk: []ReasonCode{ReasonInvokeExpr},
+			noRisk:   []ReasonCode{ReasonDestructive},
 		},
 		{
 			command:  "$x = 'foo'; Write-Output $x",
@@ -54,13 +61,23 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 			command:  "Write-Output $(Get-Date)",
 			wantRisk: []ReasonCode{ReasonSubshell},
 		},
+		// Destructive commands must emit ReasonDestructive, NOT ReasonInvokeExpr.
+		{
+			command:  "Remove-Item foo.txt",
+			wantRisk: []ReasonCode{ReasonDestructive},
+			noRisk:   []ReasonCode{ReasonInvokeExpr},
+		},
+		{
+			command:  "Copy-Item src dst",
+			wantRisk: []ReasonCode{ReasonDestructive},
+			noRisk:   []ReasonCode{ReasonInvokeExpr},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.command, func(t *testing.T) {
 			ir, err := p.Parse(tc.command)
-			// Bridge errors are allowed for problematic syntax but must produce a valid IR.
-			_ = err
+			_ = err // bridge errors produce valid IR
 
 			if ir.Version != IRVersion {
 				t.Errorf("Version: got %q want %q", ir.Version, IRVersion)
@@ -97,27 +114,154 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 	}
 }
 
-// TestWindowsParser_FailClosed ensures the adapter fails safely when pwsh is
-// absent or the bridge emits garbage.
-func TestWindowsParser_FailClosed(t *testing.T) {
-	// Simulate unavailable shell by using an empty path override in a test-only way.
-	// We can't easily do this without the sync.Once, so just check the IR contract
-	// on a real parse with a clearly broken input.
-	if _, err := exec.LookPath("pwsh.exe"); err != nil {
-		if _, err2 := exec.LookPath("powershell.exe"); err2 != nil {
-			t.Skip("pwsh/powershell not available")
-		}
+// TestWindowsParser_SanitizeCommand verifies that sanitizeCommand rejects
+// null bytes and over-length commands before touching the bridge.
+func TestWindowsParser_SanitizeCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		wantErr bool
+	}{
+		{"valid", "Get-ChildItem", false},
+		{"null byte", "Get-\x00ChildItem", true},
+		{"empty", "", false},
+		{"exactly at limit", strings.Repeat("a", maxCommandBytes), false},
+		{"one over limit", strings.Repeat("a", maxCommandBytes+1), true},
 	}
 
-	p := &WindowsParser{}
-	// Malformed input — PS parser should still emit something but we verify
-	// the Go layer never panics and returns a usable IR.
-	ir, _ := p.Parse("if (")
-
-	if ir.Version != IRVersion {
-		t.Errorf("Version must be set even on parse error, got %q", ir.Version)
-	}
-	if ir.Platform != PlatformWindows {
-		t.Errorf("Platform must be set even on parse error")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sanitizeCommand(tc.command)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("sanitizeCommand() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
 	}
 }
+
+// TestWindowsParser_SanitizeCommand_IRShape verifies that sanitize failures
+// produce a well-formed IR with ReasonSyntaxError (not a panic).
+func TestWindowsParser_SanitizeCommand_IRShape(t *testing.T) {
+	p := &WindowsParser{}
+
+	ir, err := p.Parse("bad\x00command")
+	if err == nil {
+		t.Fatal("expected error for null-byte command")
+	}
+	if ir.Version != IRVersion {
+		t.Errorf("Version must be set on sanitize failure, got %q", ir.Version)
+	}
+	if ir.Platform != PlatformWindows {
+		t.Errorf("Platform must be set on sanitize failure")
+	}
+	if !hasRisk(ir, ReasonSyntaxError) {
+		t.Errorf("expected ReasonSyntaxError in risk flags, got %v", ir.RiskFlags)
+	}
+}
+
+// TestWindowsParser_ParseErrorShape verifies that a syntactically invalid
+// command still produces a valid IR with ReasonSyntaxError and correct
+// version/platform — the bridge never panics and the Go layer never panics.
+func TestWindowsParser_ParseErrorShape(t *testing.T) {
+	skipIfNoPwsh(t)
+
+	p := &WindowsParser{}
+	ir, _ := p.Parse("if (") // incomplete — PS parser emits a soft error
+
+	if ir.Version != IRVersion {
+		t.Errorf("Version must be set on parse error, got %q", ir.Version)
+	}
+	if ir.Platform != PlatformWindows {
+		t.Errorf("Platform must be set on parse error")
+	}
+}
+
+// TestWindowsParser_Concurrent verifies that multiple goroutines can call
+// Parse simultaneously without corrupting the pipe protocol.  All calls
+// must return valid IRs.
+func TestWindowsParser_Concurrent(t *testing.T) {
+	skipIfNoPwsh(t)
+
+	p := &WindowsParser{}
+	const n = 12
+	type result struct {
+		ir  ParsedIR
+		err error
+	}
+	results := make(chan result, n)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			ir, err := p.Parse("Get-ChildItem")
+			results <- result{ir, err}
+		}()
+	}
+
+	for i := 0; i < n; i++ {
+		r := <-results
+		if r.err != nil {
+			t.Errorf("concurrent Parse error: %v", r.err)
+			continue
+		}
+		if r.ir.Version != IRVersion {
+			t.Errorf("concurrent Parse: bad version %q", r.ir.Version)
+		}
+		if r.ir.Platform != PlatformWindows {
+			t.Errorf("concurrent Parse: bad platform %q", r.ir.Platform)
+		}
+	}
+}
+
+// TestWindowsParser_BridgeRestart verifies that Parse automatically recovers
+// when the bridge process is externally killed between calls.
+func TestWindowsParser_BridgeRestart(t *testing.T) {
+	skipIfNoPwsh(t)
+
+	// Ensure a clean bridge for this test.
+	CloseBridge()
+	t.Cleanup(CloseBridge)
+
+	p := &WindowsParser{}
+
+	// First call — starts the bridge.
+	ir1, err := p.Parse("Get-ChildItem")
+	if err != nil {
+		t.Fatalf("first Parse failed: %v", err)
+	}
+	if ir1.Platform != PlatformWindows {
+		t.Fatalf("first Parse: bad platform")
+	}
+
+	// Kill the bridge externally to simulate a crash.
+	globalBridgeMu.Lock()
+	bp := globalBridge
+	globalBridgeMu.Unlock()
+
+	if bp == nil {
+		t.Fatal("expected a running bridge after first Parse")
+	}
+	bp.mu.Lock()
+	bp.dead = true
+	bp.mu.Unlock()
+	_ = bp.cmd.Process.Kill()
+	invalidateBridge(bp)
+
+	// Second call — must restart the bridge and succeed.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var ir2 ParsedIR
+	var err2 error
+	go func() {
+		defer wg.Done()
+		ir2, err2 = p.Parse("Get-Date")
+	}()
+	wg.Wait()
+
+	if err2 != nil {
+		t.Fatalf("Parse after bridge restart failed: %v", err2)
+	}
+	if ir2.Platform != PlatformWindows {
+		t.Errorf("restarted bridge: bad platform %q", ir2.Platform)
+	}
+}
+

--- a/internal/tool/ast/windows_adapter_test.go
+++ b/internal/tool/ast/windows_adapter_test.go
@@ -74,15 +74,34 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 		},
 		// Script-block arguments must NOT emit ReasonSubshell.  { } blocks are
 		// idiomatic PowerShell parameter syntax, not subshell execution.
+		// $_ is a pipeline iteration variable — also filtered, no ReasonExpansion.
 		{
-			command:  "Get-ChildItem | Where-Object { $_.Name -eq 'foo' }",
-			noRisk:   []ReasonCode{ReasonSubshell},
-			wantRisk: []ReasonCode{ReasonOperator, ReasonExpansion},
+			command: "Get-ChildItem | Where-Object { $_.Name -eq 'foo' }",
+			noRisk:  []ReasonCode{ReasonSubshell, ReasonExpansion},
+			wantRisk: []ReasonCode{ReasonOperator},
 		},
 		{
 			command:  "Get-ChildItem | ForEach-Object { Write-Output 'done' }",
 			noRisk:   []ReasonCode{ReasonSubshell},
 			wantRisk: []ReasonCode{ReasonOperator},
+		},
+		// $true/$false/$null/$_ are language constants — must NOT emit ReasonExpansion.
+		{
+			command: "Write-Output $true",
+			noRisk:  []ReasonCode{ReasonExpansion, ReasonSubshell},
+		},
+		{
+			command: "Write-Output $false",
+			noRisk:  []ReasonCode{ReasonExpansion, ReasonSubshell},
+		},
+		{
+			command: "Write-Output $null",
+			noRisk:  []ReasonCode{ReasonExpansion, ReasonSubshell},
+		},
+		// $env:VAR IS a dynamic expansion and must still emit ReasonExpansion.
+		{
+			command:  "Write-Output $env:USERNAME",
+			wantRisk: []ReasonCode{ReasonExpansion},
 		},
 	}
 

--- a/internal/tool/ast/windows_adapter_test.go
+++ b/internal/tool/ast/windows_adapter_test.go
@@ -72,6 +72,18 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 			wantRisk: []ReasonCode{ReasonDestructive},
 			noRisk:   []ReasonCode{ReasonInvokeExpr},
 		},
+		// Script-block arguments must NOT emit ReasonSubshell.  { } blocks are
+		// idiomatic PowerShell parameter syntax, not subshell execution.
+		{
+			command:  "Get-ChildItem | Where-Object { $_.Name -eq 'foo' }",
+			noRisk:   []ReasonCode{ReasonSubshell},
+			wantRisk: []ReasonCode{ReasonOperator, ReasonExpansion},
+		},
+		{
+			command:  "Get-ChildItem | ForEach-Object { Write-Output 'done' }",
+			noRisk:   []ReasonCode{ReasonSubshell},
+			wantRisk: []ReasonCode{ReasonOperator},
+		},
 	}
 
 	for _, tc := range tests {
@@ -244,6 +256,7 @@ func TestWindowsParser_BridgeRestart(t *testing.T) {
 	bp.dead = true
 	bp.mu.Unlock()
 	_ = bp.cmd.Process.Kill()
+	go func() { _ = bp.cmd.Wait() }()
 	invalidateBridge(bp)
 
 	// Second call — must restart the bridge and succeed.

--- a/internal/tool/ast/windows_adapter_test.go
+++ b/internal/tool/ast/windows_adapter_test.go
@@ -19,10 +19,10 @@ func TestWindowsParser_BridgeContract(t *testing.T) {
 
 	p := &WindowsParser{}
 	tests := []struct {
-		command     string
-		wantCmds    []string
-		wantRisk    []ReasonCode
-		noRisk      []ReasonCode
+		command  string
+		wantCmds []string
+		wantRisk []ReasonCode
+		noRisk   []ReasonCode
 	}{
 		{
 			command:  "Get-ChildItem",

--- a/internal/tool/ast_bridge.go
+++ b/internal/tool/ast_bridge.go
@@ -6,38 +6,6 @@ import (
 	"late/internal/tool/ast"
 )
 
-// windowsBuiltinAllowedCommands returns the hardcoded safe PowerShell cmdlets
-// that mirror whitelistedWindowsCommands in powershell_analyzer.go. These are
-// merged into AllowedCommands so the PolicyEngine auto-approves them in
-// enforcement mode without requiring the user to manually allowlist them.
-func windowsBuiltinAllowedCommands() map[string]map[string]bool {
-	builtins := []string{
-		"cat", "date", "dir", "echo",
-		"gc", "gci", "get-childitem", "get-content", "get-date", "get-location",
-		"ls", "measure-object", "pwd",
-		"select-string", "sls", "type", "whoami", "write-output",
-		"write-host",
-	}
-	m := make(map[string]map[string]bool, len(builtins))
-	for _, cmd := range builtins {
-		m[cmd] = map[string]bool{}
-	}
-	return m
-}
-
-// mergeAllowedCommands merges src into dst, returning dst.
-func mergeAllowedCommands(dst, src map[string]map[string]bool) map[string]map[string]bool {
-	for cmd, flags := range src {
-		if _, ok := dst[cmd]; !ok {
-			dst[cmd] = make(map[string]bool)
-		}
-		for f := range flags {
-			dst[cmd][f] = true
-		}
-	}
-	return dst
-}
-
 // astAnalyzer wraps the ast pipeline and implements CommandAnalyzer so it can
 // be dropped into ShellTool.getAnalyzer as a drop-in replacement (Phase 5).
 type astAnalyzer struct {
@@ -49,8 +17,13 @@ type astAnalyzer struct {
 func newASTAnalyzer(platform ast.Platform, cwd string, allowed map[string]map[string]bool) *astAnalyzer {
 	// On Windows, seed the policy engine with the built-in safe cmdlets so
 	// that Get-ChildItem, ls, pwd etc. auto-approve without user allowlisting.
+	// Source of truth is whitelistedWindowsCommands in powershell_analyzer.go.
 	if runtime.GOOS == "windows" {
-		allowed = mergeAllowedCommands(allowed, windowsBuiltinAllowedCommands())
+		for cmd := range whitelistedWindowsCommands {
+			if _, ok := allowed[cmd]; !ok {
+				allowed[cmd] = map[string]bool{}
+			}
+		}
 	}
 	return &astAnalyzer{
 		parser: ast.NewParser(platform, cwd),
@@ -67,16 +40,14 @@ func (a *astAnalyzer) Analyze(command string) CommandAnalysis {
 	}
 	d := a.policy.Decide(ir)
 
-	// New-path boundary guard: PolicyEngine rule 8 auto-approves ReasonNewPath
-	// without knowing the session cwd. On Windows, verify the mkdir/New-Item
-	// target is actually within cwd before accepting that auto-approval.
-	// If we can't confirm the target is within cwd, upgrade to confirm.
-	if !d.NeedsConfirmation && !d.IsBlocked && ir.Platform == ast.PlatformWindows {
+	// New-path carveout: PolicyEngine conservatively requires confirmation for
+	// mkdir/New-Item (it has no cwd context). Here we have the session cwd, so
+	// if the sole risk signal is ReasonNewPath and the target is within cwd,
+	// downgrade to auto-approve — matching the legacy PowerShellAnalyzer behaviour.
+	if d.NeedsConfirmation && !d.IsBlocked && ir.Platform == ast.PlatformWindows {
 		if ast.HasRiskOnly(ir, ast.ReasonNewPath) {
-			target := extractPowerShellTargetPath(command)
-			if target == "" || !isNewPath(target, a.cwd) {
-				// Target outside cwd or path can't be determined — require confirmation.
-				return CommandAnalysis{NeedsConfirmation: true}
+			if target := extractPowerShellTargetPath(command); target != "" && isNewPath(target, a.cwd) {
+				return CommandAnalysis{NeedsConfirmation: false}
 			}
 		}
 	}

--- a/internal/tool/ast_bridge.go
+++ b/internal/tool/ast_bridge.go
@@ -1,0 +1,63 @@
+package tool
+
+import (
+	"late/internal/tool/ast"
+)
+
+// astAnalyzer wraps the ast pipeline and implements CommandAnalyzer so it can
+// be dropped into ShellTool.getAnalyzer as a drop-in replacement (Phase 5).
+type astAnalyzer struct {
+	parser ast.Parser
+	policy *ast.PolicyEngine
+}
+
+func newASTAnalyzer(platform ast.Platform, cwd string, allowed map[string]map[string]bool) *astAnalyzer {
+	return &astAnalyzer{
+		parser: ast.NewParser(platform, cwd),
+		policy: &ast.PolicyEngine{AllowedCommands: allowed},
+	}
+}
+
+func (a *astAnalyzer) Analyze(command string) CommandAnalysis {
+	ir, err := a.parser.Parse(command)
+	if err != nil {
+		// Fail closed on any parse error.
+		return CommandAnalysis{NeedsConfirmation: true}
+	}
+	d := a.policy.Decide(ir)
+	return CommandAnalysis{
+		IsBlocked:         d.IsBlocked,
+		BlockReason:       d.BlockReason,
+		NeedsConfirmation: d.NeedsConfirmation,
+	}
+}
+
+// shadowAnalyzerShim bridges the ast.LegacyAnalysis interface with the
+// concrete CommandAnalyzer types in this package so ShadowAnalyzer can wrap
+// them without importing tool (which would be circular).
+type shadowAnalyzerShim struct {
+	inner CommandAnalyzer
+}
+
+func (s *shadowAnalyzerShim) Analyze(command string) ast.LegacyAnalysis {
+	ca := s.inner.Analyze(command)
+	return ast.LegacyAnalysis{
+		IsBlocked:         ca.IsBlocked,
+		BlockReason:       ca.BlockReason,
+		NeedsConfirmation: ca.NeedsConfirmation,
+	}
+}
+
+// shadowWrapper wraps an ast.ShadowAnalyzer and implements CommandAnalyzer.
+type shadowWrapper struct {
+	shadow *ast.ShadowAnalyzer
+}
+
+func (sw *shadowWrapper) Analyze(command string) CommandAnalysis {
+	la := sw.shadow.Analyze(command)
+	return CommandAnalysis{
+		IsBlocked:         la.IsBlocked,
+		BlockReason:       la.BlockReason,
+		NeedsConfirmation: la.NeedsConfirmation,
+	}
+}

--- a/internal/tool/ast_bridge.go
+++ b/internal/tool/ast_bridge.go
@@ -1,8 +1,6 @@
 package tool
 
 import (
-	"runtime"
-
 	"late/internal/tool/ast"
 )
 
@@ -18,7 +16,9 @@ func newASTAnalyzer(platform ast.Platform, cwd string, allowed map[string]map[st
 	// On Windows, seed the policy engine with the built-in safe cmdlets so
 	// that Get-ChildItem, ls, pwd etc. auto-approve without user allowlisting.
 	// Source of truth is whitelistedWindowsCommands in powershell_analyzer.go.
-	if runtime.GOOS == "windows" {
+	// Check the platform parameter (not runtime.GOOS) so behaviour is consistent
+	// when platform is overridden, e.g. in cross-platform tests.
+	if platform == ast.PlatformWindows {
 		for cmd := range whitelistedWindowsCommands {
 			if _, ok := allowed[cmd]; !ok {
 				allowed[cmd] = map[string]bool{}

--- a/internal/tool/ast_bridge.go
+++ b/internal/tool/ast_bridge.go
@@ -67,14 +67,16 @@ func (a *astAnalyzer) Analyze(command string) CommandAnalysis {
 	}
 	d := a.policy.Decide(ir)
 
-	// New-path carveout: if the only signal is ReasonNewPath (mkdir/New-Item
-	// creating a net-new path within the cwd), apply the same auto-approval
-	// the legacy PowerShellAnalyzer uses. This check runs in Go so we can
-	// call isNewPath with the session cwd without touching the bridge.
-	if d.NeedsConfirmation && !d.IsBlocked && ir.Platform == ast.PlatformWindows {
+	// New-path boundary guard: PolicyEngine rule 8 auto-approves ReasonNewPath
+	// without knowing the session cwd. On Windows, verify the mkdir/New-Item
+	// target is actually within cwd before accepting that auto-approval.
+	// If we can't confirm the target is within cwd, upgrade to confirm.
+	if !d.NeedsConfirmation && !d.IsBlocked && ir.Platform == ast.PlatformWindows {
 		if ast.HasRiskOnly(ir, ast.ReasonNewPath) {
-			if target := extractPowerShellTargetPath(command); target != "" && isNewPath(target, a.cwd) {
-				return CommandAnalysis{NeedsConfirmation: false}
+			target := extractPowerShellTargetPath(command)
+			if target == "" || !isNewPath(target, a.cwd) {
+				// Target outside cwd or path can't be determined — require confirmation.
+				return CommandAnalysis{NeedsConfirmation: true}
 			}
 		}
 	}

--- a/internal/tool/ast_bridge.go
+++ b/internal/tool/ast_bridge.go
@@ -1,20 +1,61 @@
 package tool
 
 import (
+	"runtime"
+
 	"late/internal/tool/ast"
 )
+
+// windowsBuiltinAllowedCommands returns the hardcoded safe PowerShell cmdlets
+// that mirror whitelistedWindowsCommands in powershell_analyzer.go. These are
+// merged into AllowedCommands so the PolicyEngine auto-approves them in
+// enforcement mode without requiring the user to manually allowlist them.
+func windowsBuiltinAllowedCommands() map[string]map[string]bool {
+	builtins := []string{
+		"cat", "date", "dir", "echo",
+		"gc", "gci", "get-childitem", "get-content", "get-date", "get-location",
+		"ls", "measure-object", "pwd",
+		"select-string", "sls", "type", "whoami", "write-output",
+		"write-host",
+	}
+	m := make(map[string]map[string]bool, len(builtins))
+	for _, cmd := range builtins {
+		m[cmd] = map[string]bool{}
+	}
+	return m
+}
+
+// mergeAllowedCommands merges src into dst, returning dst.
+func mergeAllowedCommands(dst, src map[string]map[string]bool) map[string]map[string]bool {
+	for cmd, flags := range src {
+		if _, ok := dst[cmd]; !ok {
+			dst[cmd] = make(map[string]bool)
+		}
+		for f := range flags {
+			dst[cmd][f] = true
+		}
+	}
+	return dst
+}
 
 // astAnalyzer wraps the ast pipeline and implements CommandAnalyzer so it can
 // be dropped into ShellTool.getAnalyzer as a drop-in replacement (Phase 5).
 type astAnalyzer struct {
 	parser ast.Parser
 	policy *ast.PolicyEngine
+	cwd    string
 }
 
 func newASTAnalyzer(platform ast.Platform, cwd string, allowed map[string]map[string]bool) *astAnalyzer {
+	// On Windows, seed the policy engine with the built-in safe cmdlets so
+	// that Get-ChildItem, ls, pwd etc. auto-approve without user allowlisting.
+	if runtime.GOOS == "windows" {
+		allowed = mergeAllowedCommands(allowed, windowsBuiltinAllowedCommands())
+	}
 	return &astAnalyzer{
 		parser: ast.NewParser(platform, cwd),
 		policy: &ast.PolicyEngine{AllowedCommands: allowed},
+		cwd:    cwd,
 	}
 }
 
@@ -25,6 +66,19 @@ func (a *astAnalyzer) Analyze(command string) CommandAnalysis {
 		return CommandAnalysis{NeedsConfirmation: true}
 	}
 	d := a.policy.Decide(ir)
+
+	// New-path carveout: if the only signal is ReasonNewPath (mkdir/New-Item
+	// creating a net-new path within the cwd), apply the same auto-approval
+	// the legacy PowerShellAnalyzer uses. This check runs in Go so we can
+	// call isNewPath with the session cwd without touching the bridge.
+	if d.NeedsConfirmation && !d.IsBlocked && ir.Platform == ast.PlatformWindows {
+		if ast.HasRiskOnly(ir, ast.ReasonNewPath) {
+			if target := extractPowerShellTargetPath(command); target != "" && isNewPath(target, a.cwd) {
+				return CommandAnalysis{NeedsConfirmation: false}
+			}
+		}
+	}
+
 	return CommandAnalysis{
 		IsBlocked:         d.IsBlocked,
 		BlockReason:       d.BlockReason,

--- a/internal/tool/ast_mode_test.go
+++ b/internal/tool/ast_mode_test.go
@@ -1,0 +1,164 @@
+//go:build windows
+
+package tool
+
+import (
+	"os/exec"
+	"testing"
+
+	"late/internal/tool/ast"
+)
+
+func skipIfNoPwshTool(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("pwsh.exe"); err != nil {
+		if _, err2 := exec.LookPath("powershell.exe"); err2 != nil {
+			t.Skip("pwsh/powershell not available")
+		}
+	}
+}
+
+// TestGetAnalyzer_NoFlags verifies the no-flag code path returns the
+// platform-native legacy analyzer on Windows.
+func TestGetAnalyzer_NoFlags(t *testing.T) {
+	t.Setenv(ast.EnvASTEnforcement, "")
+	t.Setenv(ast.EnvASTShadow, "")
+
+	tool := &ShellTool{}
+	analyzer := tool.getAnalyzer(t.TempDir())
+
+	if _, ok := analyzer.(*PowerShellAnalyzer); !ok {
+		t.Errorf("expected *PowerShellAnalyzer with no feature flags, got %T", analyzer)
+	}
+}
+
+// TestGetAnalyzer_ShadowMode verifies that LATE_AST_SHADOW=1 wraps the legacy
+// analyzer in a shadowWrapper without changing the returned type.
+func TestGetAnalyzer_ShadowMode(t *testing.T) {
+	t.Setenv(ast.EnvASTShadow, "1")
+	t.Setenv(ast.EnvASTEnforcement, "")
+
+	tool := &ShellTool{}
+	analyzer := tool.getAnalyzer(t.TempDir())
+
+	if _, ok := analyzer.(*shadowWrapper); !ok {
+		t.Errorf("expected *shadowWrapper in shadow mode, got %T", analyzer)
+	}
+}
+
+// TestGetAnalyzer_EnforcementMode verifies that LATE_AST_ENFORCEMENT=1 returns
+// an astAnalyzer and that LATE_AST_SHADOW is ignored when enforcement is set.
+func TestGetAnalyzer_EnforcementMode(t *testing.T) {
+	t.Setenv(ast.EnvASTEnforcement, "1")
+	t.Setenv(ast.EnvASTShadow, "")
+
+	tool := &ShellTool{}
+	analyzer := tool.getAnalyzer(t.TempDir())
+
+	if _, ok := analyzer.(*astAnalyzer); !ok {
+		t.Errorf("expected *astAnalyzer in enforcement mode, got %T", analyzer)
+	}
+}
+
+// TestGetAnalyzer_EnforcementTakesPrecedence verifies enforcement wins when
+// both flags are set simultaneously.
+func TestGetAnalyzer_EnforcementTakesPrecedence(t *testing.T) {
+	t.Setenv(ast.EnvASTEnforcement, "1")
+	t.Setenv(ast.EnvASTShadow, "1")
+
+	tool := &ShellTool{}
+	analyzer := tool.getAnalyzer(t.TempDir())
+
+	if _, ok := analyzer.(*astAnalyzer); !ok {
+		t.Errorf("expected *astAnalyzer when both flags set, got %T", analyzer)
+	}
+}
+
+// TestEnforcementMode_SafeCommandAutoApproves verifies that a known-safe
+// cmdlet auto-approves (no confirmation required) when the AST pipeline is
+// authoritative.
+func TestEnforcementMode_SafeCommandAutoApproves(t *testing.T) {
+	skipIfNoPwshTool(t)
+	t.Setenv(ast.EnvASTEnforcement, "1")
+	t.Setenv(ast.EnvASTShadow, "")
+
+	tool := &ShellTool{}
+	blocked, _, confirm := tool.analyzeBashCommand("Get-ChildItem", t.TempDir())
+	if blocked || confirm {
+		t.Errorf("Get-ChildItem should auto-approve in enforcement mode: blocked=%v confirm=%v", blocked, confirm)
+	}
+}
+
+// TestEnforcementMode_RiskyCommandRequiresConfirm verifies that a destructive
+// cmdlet requires confirmation (not blocked) in enforcement mode.
+func TestEnforcementMode_RiskyCommandRequiresConfirm(t *testing.T) {
+	skipIfNoPwshTool(t)
+	t.Setenv(ast.EnvASTEnforcement, "1")
+	t.Setenv(ast.EnvASTShadow, "")
+
+	tool := &ShellTool{}
+	blocked, _, confirm := tool.analyzeBashCommand("Remove-Item foo.txt", t.TempDir())
+	if blocked {
+		t.Errorf("Remove-Item should not be hard-blocked, only NeedsConfirmation")
+	}
+	if !confirm {
+		t.Errorf("Remove-Item should require confirmation in enforcement mode")
+	}
+}
+
+// TestEnforcementMode_CdIsBlocked verifies the hard-block path in enforcement mode.
+func TestEnforcementMode_CdIsBlocked(t *testing.T) {
+	skipIfNoPwshTool(t)
+	t.Setenv(ast.EnvASTEnforcement, "1")
+	t.Setenv(ast.EnvASTShadow, "")
+
+	tool := &ShellTool{}
+	blocked, blockReason, _ := tool.analyzeBashCommand("cd C:\\tmp", t.TempDir())
+	if !blocked {
+		t.Errorf("cd should be hard-blocked in enforcement mode")
+	}
+	if blockReason == nil {
+		t.Errorf("cd hard block must carry a non-nil BlockReason")
+	}
+}
+
+// TestEnforcementMode_ConstantVarNoConfirm verifies that $true/$false/$null do
+// not trigger confirmation in enforcement mode (false-positive regression test).
+func TestEnforcementMode_ConstantVarNoConfirm(t *testing.T) {
+	skipIfNoPwshTool(t)
+	t.Setenv(ast.EnvASTEnforcement, "1")
+	t.Setenv(ast.EnvASTShadow, "")
+
+	tool := &ShellTool{}
+	for _, cmd := range []string{
+		"Write-Output $true",
+		"Write-Output $false",
+		"Write-Output $null",
+	} {
+		blocked, _, confirm := tool.analyzeBashCommand(cmd, t.TempDir())
+		if blocked || confirm {
+			t.Errorf("%q should auto-approve (constant var, not dynamic expansion): blocked=%v confirm=%v",
+				cmd, blocked, confirm)
+		}
+	}
+}
+
+// TestShadowMode_ReturnsLegacyDecision verifies that shadow mode returns the
+// legacy result (no behavior change) even when the AST pipeline is running.
+func TestShadowMode_ReturnsLegacyDecision(t *testing.T) {
+	skipIfNoPwshTool(t)
+	t.Setenv(ast.EnvASTShadow, "1")
+	t.Setenv(ast.EnvASTEnforcement, "")
+
+	tool := &ShellTool{}
+	// Get-ChildItem is safe in both legacy and AST paths.
+	blocked, _, confirm := tool.analyzeBashCommand("Get-ChildItem", t.TempDir())
+	if blocked || confirm {
+		t.Errorf("shadow mode must return legacy result for Get-ChildItem: blocked=%v confirm=%v", blocked, confirm)
+	}
+	// Remove-Item is risky in both paths.
+	_, _, confirm = tool.analyzeBashCommand("Remove-Item foo.txt", t.TempDir())
+	if !confirm {
+		t.Errorf("shadow mode must return legacy result for Remove-Item: expected confirm=true")
+	}
+}

--- a/internal/tool/ast_mode_test.go
+++ b/internal/tool/ast_mode_test.go
@@ -33,7 +33,7 @@ func TestGetAnalyzer_NoFlags(t *testing.T) {
 }
 
 // TestGetAnalyzer_ShadowMode verifies that LATE_AST_SHADOW=1 wraps the legacy
-// analyzer in a shadowWrapper without changing the returned type.
+// analyzer in a shadowWrapper without changing behavior/decision flow.
 func TestGetAnalyzer_ShadowMode(t *testing.T) {
 	t.Setenv(ast.EnvASTShadow, "1")
 	t.Setenv(ast.EnvASTEnforcement, "")

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"late/internal/common"
+	"late/internal/tool/ast"
 )
 
 // ReadFileTool reads content from a file.
@@ -171,11 +172,29 @@ func (t WriteFileTool) CallString(args json.RawMessage) string {
 }
 
 func (t *ShellTool) getAnalyzer(cwd string) CommandAnalyzer {
-	if runtime.GOOS == "windows" {
-		return &PowerShellAnalyzer{Cwd: cwd}
-	}
+	platform := ast.CurrentPlatform()
 	allowed, _ := LoadAllAllowedCommands()
-	return &BashAnalyzer{ProjectAllowedCommands: allowed}
+
+	// Phase 5: AST enforcement — AST pipeline is authoritative.
+	if ast.FeatureASTEnforcement() {
+		return newASTAnalyzer(platform, cwd, allowed)
+	}
+
+	// Build the legacy analyzer for this platform.
+	var legacy CommandAnalyzer
+	if runtime.GOOS == "windows" {
+		legacy = &PowerShellAnalyzer{Cwd: cwd}
+	} else {
+		legacy = &BashAnalyzer{ProjectAllowedCommands: allowed}
+	}
+
+	// Phase 4: AST shadow mode — run AST in parallel, log deltas, return legacy.
+	if ast.FeatureASTShadow() {
+		shadow := ast.NewShadowAnalyzer(&shadowAnalyzerShim{inner: legacy}, platform, cwd, allowed)
+		return &shadowWrapper{shadow: shadow}
+	}
+
+	return legacy
 }
 
 // SaveToAllowList persists a command to the allow-list. Defaults to local scope.

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -173,10 +173,10 @@ func (t WriteFileTool) CallString(args json.RawMessage) string {
 
 func (t *ShellTool) getAnalyzer(cwd string) CommandAnalyzer {
 	platform := ast.CurrentPlatform()
-	allowed, _ := LoadAllAllowedCommands()
 
 	// Phase 5: AST enforcement — AST pipeline is authoritative.
 	if ast.FeatureASTEnforcement() {
+		allowed, _ := LoadAllAllowedCommands()
 		return newASTAnalyzer(platform, cwd, allowed)
 	}
 
@@ -185,11 +185,23 @@ func (t *ShellTool) getAnalyzer(cwd string) CommandAnalyzer {
 	if runtime.GOOS == "windows" {
 		legacy = &PowerShellAnalyzer{Cwd: cwd}
 	} else {
+		allowed, _ := LoadAllAllowedCommands()
 		legacy = &BashAnalyzer{ProjectAllowedCommands: allowed}
 	}
 
 	// Phase 4: AST shadow mode — run AST in parallel, log deltas, return legacy.
 	if ast.FeatureASTShadow() {
+		allowed, _ := LoadAllAllowedCommands()
+		// Seed shadow's policy engine with the built-in safe cmdlets on Windows
+		// so that commands like Get-ChildItem don't always appear as
+		// confirm-required and generate noisy/useless deltas.
+		if runtime.GOOS == "windows" {
+			for cmd := range whitelistedWindowsCommands {
+				if _, ok := allowed[cmd]; !ok {
+					allowed[cmd] = map[string]bool{}
+				}
+			}
+		}
 		shadow := ast.NewShadowAnalyzer(&shadowAnalyzerShim{inner: legacy}, platform, cwd, allowed)
 		return &shadowWrapper{shadow: shadow}
 	}

--- a/internal/tool/permissions.go
+++ b/internal/tool/permissions.go
@@ -468,17 +468,14 @@ func SaveAllowedCommand(command string, global bool) error {
 	touched := make(map[string]bool)
 
 	for key, flags := range commands {
-		existingFlags, exists := allowed[key]
+		_, exists := allowed[key]
 		if !exists {
 			allowed[key] = make(map[string]bool)
-			touched[key] = true
-		} else if len(flags) == 0 && !touched[key] {
-			touched[key] = false
 		}
+		// Always mark as touched so the TTL is refreshed on any explicit approval,
+		// including re-approving a command that was already in the allow-list.
+		touched[key] = true
 		for _, flag := range flags {
-			if !exists || !existingFlags[flag] {
-				touched[key] = true
-			}
 			allowed[key][flag] = true
 		}
 	}
@@ -610,7 +607,6 @@ func SaveAllowedTool(name string, global bool) error {
 		return err
 	}
 
-	_, alreadyAllowed := allowed[name]
 	allowed[name] = true
 
 	file := persistedToolsFile{
@@ -627,10 +623,14 @@ func SaveAllowedTool(name string, global bool) error {
 			ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
 			Version:   common.Version,
 		}
-		if existingEntry, ok := existingFile.Entries[toolName]; ok && (toolName != name || alreadyAllowed) {
-			entry.SavedAt = existingEntry.SavedAt
-			entry.ExpiresAt = existingEntry.ExpiresAt
-			entry.Version = existingEntry.Version
+		// For tools other than the one being newly approved, preserve existing
+		// timestamps so their TTL is not accidentally reset by an unrelated save.
+		if toolName != name {
+			if existingEntry, ok := existingFile.Entries[toolName]; ok {
+				entry.SavedAt = existingEntry.SavedAt
+				entry.ExpiresAt = existingEntry.ExpiresAt
+				entry.Version = existingEntry.Version
+			}
 		}
 		file.Entries[toolName] = entry
 	}

--- a/internal/tool/permissions.go
+++ b/internal/tool/permissions.go
@@ -97,6 +97,11 @@ func isNewPath(path string, cwd string) bool {
 		return false
 	}
 
+	// Safety check uses the symlink-resolved canonical path to prevent
+	// symlink-escape attacks.  Existence check intentionally uses the
+	// pre-resolved absPath: os.Stat follows symlinks, so if absPath IS a
+	// symlink, Stat reflects the link target's existence—which is correct for
+	// "does this path already exist" semantics.
 	_, err = os.Stat(absPath)
 	return os.IsNotExist(err)
 }

--- a/internal/tool/powershell_analyzer.go
+++ b/internal/tool/powershell_analyzer.go
@@ -23,6 +23,7 @@ var whitelistedWindowsCommands = map[string]bool{
 	"sls":            true,
 	"type":           true,
 	"whoami":         true,
+	"write-host":     true,
 	"write-output":   true,
 }
 
@@ -191,10 +192,23 @@ func extractPowerShellTargetPath(command string) string {
 	case "mkdir", "md":
 		target = tokens[1]
 	case "new-item", "ni":
-		if len(tokens) == 2 {
-			target = tokens[1]
-		} else if len(tokens) >= 3 && strings.EqualFold(tokens[1], "-Path") {
-			target = tokens[2]
+		// Scan for explicit -Path flag first, then fall back to the first
+		// positional (non-flag) argument.  This handles argument orders like:
+		//   New-Item foo
+		//   New-Item -Path foo
+		//   New-Item -ItemType Directory -Path foo
+		//   New-Item -Path foo -ItemType Directory
+		for i := 1; i < len(tokens); i++ {
+			if strings.EqualFold(tokens[i], "-Path") || strings.EqualFold(tokens[i], "-p") {
+				if i+1 < len(tokens) && !strings.HasPrefix(tokens[i+1], "-") {
+					target = tokens[i+1]
+				}
+				break
+			}
+			if !strings.HasPrefix(tokens[i], "-") {
+				target = tokens[i]
+				break
+			}
 		}
 	default:
 		return ""

--- a/internal/tool/powershell_analyzer.go
+++ b/internal/tool/powershell_analyzer.go
@@ -192,8 +192,9 @@ func extractPowerShellTargetPath(command string) string {
 	case "mkdir", "md":
 		target = tokens[1]
 	case "new-item", "ni":
-		// Scan for explicit -Path flag first, then fall back to the first
-		// positional (non-flag) argument.  This handles argument orders like:
+		// Two-pass scan: first look for an explicit -Path flag anywhere in the
+		// argument list; then fall back to the first positional (non-flag)
+		// argument.  The two-pass approach handles all argument orders:
 		//   New-Item foo
 		//   New-Item -Path foo
 		//   New-Item -ItemType Directory -Path foo
@@ -205,9 +206,13 @@ func extractPowerShellTargetPath(command string) string {
 				}
 				break
 			}
-			if !strings.HasPrefix(tokens[i], "-") {
-				target = tokens[i]
-				break
+		}
+		if target == "" {
+			for i := 1; i < len(tokens); i++ {
+				if !strings.HasPrefix(tokens[i], "-") {
+					target = tokens[i]
+					break
+				}
 			}
 		}
 	default:


### PR DESCRIPTION
## AST-backed Windows PowerShell command analysis

This PR implements a full AST-backed analysis pipeline for PowerShell commands on Windows, replacing the existing string-matching `PowerShellAnalyzer` with a parse-tree driven approach backed by `System.Management.Automation.Language.Parser` — the same parser PowerShell itself uses.

The implementation ships with a gradual rollout system: legacy behavior is the default, shadow mode (log deltas, no behavior change) is opt-in via `LATE_AST_SHADOW=1`, and full enforcement via `LATE_AST_ENFORCEMENT=1`.

---

## Architecture

### `internal/tool/ast/` — new package

| File | Purpose |
|------|---------|
| `ir.go` | `ParsedIR` schema, `ReasonCode` constants, `Parser` interface |
| `ps_bridge.ps1` | Persistent PowerShell bridge process — parses via SMA.Language.Parser, emits line-delimited JSON IR |
| `windows_adapter.go` | Go side of bridge — singleton `bridgeProcess`, `roundTrip`, `Parse`, `CloseBridge` |
| `unix_adapter.go` | In-process Unix/bash adapter via `mvdan.cc/sh/v3` |
| `policy.go` | Platform-neutral `PolicyEngine.Decide(ir)` — all decisions derived from `ParsedIR` only |
| `shadow.go` | `ShadowAnalyzer` — runs AST in parallel with legacy, logs deltas, returns legacy result |
| `registry.go` | `NewParser(platform, cwd)` factory |
| `feature_flag.go` | `LATE_AST_SHADOW` / `LATE_AST_ENFORCEMENT` env var readers |

### `internal/tool/ast_bridge.go` — integration shim

Wires the `ast` package into `ShellTool.getAnalyzer()`. Routes between legacy, shadow, and enforcement modes based on feature flags. Seeds the Windows policy engine with the built-in safe cmdlet allow-list from `whitelistedWindowsCommands`.

---

## Key design decisions

### Persistent bridge process (not per-call spawn)

The initial approach spawned `pwsh.exe` per command (~700ms each). The final design uses a singleton `bridgeProcess` per Go process lifetime. Protocol: line-delimited JSON — `{"cmd":"..."}` request → one compact JSON IR response — bridge exits on stdin EOF. First call: ~700ms (amortised). All subsequent calls: ~1ms IPC round-trip.

### Fail-closed guarantee

Every code path that cannot produce a valid parse — sanitize failure, transport error, bridge crash, schema version mismatch, unknown risk flag — returns a `ParsedIR` with `ReasonSyntaxError` and a non-nil error. The policy engine and `astAnalyzer` both treat any error as `NeedsConfirmation=true`.

### Typed `ReasonCode` constants

All risk signals are typed constants validated on both sides of the transport. Unknown flags from the bridge are rejected with `ReasonSyntaxError`, preventing a compromised bridge script from silently suppressing risk signals.

### `ReasonDestructive` — semantically distinct from `ReasonInvokeExpr`

File-modification cmdlets (`Remove-Item`, `Copy-Item`, `Move-Item`, `Set-Content`, etc.) require user confirmation but are meaningfully different from dynamic-evaluation constructs (`Invoke-Expression`, `iex`). They get their own reason code and policy slot.

---

## Risk signal reference

| `ReasonCode` | Triggers | Policy outcome |
|---|---|---|
| `operator` | `\|`, `&&`, `\|\|`, `;` | Confirm unless all cmds allowlisted |
| `redirect` | `>`, `>>` to non-safe target | **Hard block** |
| `expansion` | `$var` (non-constant) | Confirm |
| `subshell` | `$(...)`, `(...)` | Confirm |
| `invoke_expression` | `iex`, `Invoke-Expression`, `-EncodedCommand` | Confirm |
| `cd` | `cd`, `Set-Location`, `Push-Location` | **Hard block** |
| `syntax_error` | Parse failure, transport error | Confirm (fail-closed) |
| `new_path` | `mkdir`, `New-Item` | Confirm (carveout: auto-approve if target is new path within cwd) |
| `destructive` | `Remove-Item`, `Copy-Item`, `Move-Item`, `Set-Content`, etc. | Confirm |

**Not flagged:** `$true`, `$false`, `$null`, `$_`, `$PSItem` — PowerShell language constants, filtered in the bridge before emitting `ReasonExpansion`. Avoids false-positive confirmation on `Where-Object { $_.Name -eq 'foo' }`.

**Not flagged:** `{ }` script-block expressions — idiomatic PS parameter syntax. `ScriptBlockExpressionAst` was deliberately excluded. Risk from dynamic execution is caught via `Invoke-Command` in `$invokeRiskCmdlets`, not the bare block node.

---

## Bugs fixed (vs. pre-PR baseline)

1. `write-host` missing from `whitelistedWindowsCommands` — prod/test divergence
2. `Remove-Item`/`Copy-Item` emitting `invoke_expression` — wrong semantic label
3. `gofmt` failure in `windows_adapter.go`
4. Goroutine blocked on timeout: stdin not closed → blocked goroutine until bridge process exit
5. No bridge shutdown path — no way to cleanly tear down the bridge
6. Error path used `Process.Kill()` directly — no stdin-close-first, leaving bridge in inconsistent state
7. Policy comment "Pure pipe" was wrong — rule covers all operators, not just pipes
8. `extractPowerShellTargetPath` didn't handle `New-Item -ItemType Directory -Path foo`
9. `isNewPath` `absPath` vs `canonicalPath` split was undocumented
10. `ScriptBlockExpressionAst` emitted `ReasonSubshell` — false-positive on all `Where-Object`/`ForEach-Object` blocks
11. `$true`/`$false`/`$null`/`$_` emitted `ReasonExpansion` — false-positive on constant variables
12. `snapshot_test.go` had no build tag — Windows corpus silently skipped on Linux CI
13. `startBridgeProcess` leaked stdin pipe on `StdoutPipe`/`Start()` failure
14. `TestWindowsParser_BridgeRestart` didn't `Wait()` the killed process
15. Feature flag routing (`getAnalyzer`) had no integration tests

---

## Tests added

### `internal/tool/ast/`

- `TestWindowsParser_BridgeContract` — 13 command patterns verifying exact risk flag contract
- `TestWindowsParser_SanitizeCommand` — null byte, length limit, boundary cases
- `TestWindowsParser_SanitizeCommand_IRShape` — sanitize failure produces valid IR
- `TestWindowsParser_ParseErrorShape` — bridge never panics on invalid input
- `TestWindowsParser_Concurrent` — 12 goroutines simultaneously, validates pipe protocol integrity
- `TestWindowsParser_BridgeRestart` — kills bridge externally, verifies auto-restart
- `TestWindowsCorpusSnapshot` _(Windows-only)_ — 22-entry corpus against full policy engine
- `TestPolicyEngine_Decide_SoftSignals` — extended to include `ReasonDestructive`

### `internal/tool/`

- `TestGetAnalyzer_NoFlags` — no flags → `*PowerShellAnalyzer`
- `TestGetAnalyzer_ShadowMode` — `LATE_AST_SHADOW=1` → `*shadowWrapper`
- `TestGetAnalyzer_EnforcementMode` — `LATE_AST_ENFORCEMENT=1` → `*astAnalyzer`
- `TestGetAnalyzer_EnforcementTakesPrecedence` — both flags set → `*astAnalyzer`
- `TestEnforcementMode_SafeCommandAutoApproves` — end-to-end: `Get-ChildItem` auto-approves
- `TestEnforcementMode_RiskyCommandRequiresConfirm` — `Remove-Item` confirm-only, not blocked
- `TestEnforcementMode_CdIsBlocked` — `cd` hard-blocked with non-nil `BlockReason`
- `TestEnforcementMode_ConstantVarNoConfirm` — `$true`/`$false`/`$null` auto-approve
- `TestShadowMode_ReturnsLegacyDecision` — shadow returns legacy result unchanged

---

## Known limitations (accepted, documented in code)

- **Windows Job Object:** if the Go process crashes (panic, `os.Exit`), the `pwsh.exe` bridge is orphaned. Proper fix requires `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` via `golang.org/x/sys/windows` — deferred to a follow-up.
- **`sc` alias collision:** `sc` in `$destructiveCmdlets` also matches `sc.exe` (Windows Service Control Manager). `sc query wuauserv` would require confirmation. Documented inline in `ps_bridge.ps1`.
- **`winPSPathOnce` singleton:** shell path is detected once per process; cannot be overridden in tests without process restart.

---

## Rollout

| Phase | Flag | Behavior |
|---|---|---|
| Default (now) | _(none)_ | Legacy `PowerShellAnalyzer`, no change for existing users |
| Shadow | `LATE_AST_SHADOW=1` | AST runs in parallel, deltas logged, legacy result returned |
| Enforcement | `LATE_AST_ENFORCEMENT=1` | AST pipeline is authoritative, legacy bypassed |



### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [X ] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository.** *(To check the box, put an `x` between the brackets like this: `[x]`)*