### PR TITLE
fix: pass server.Env to NewStdioTransport in ConnectFromConfig

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -204,8 +204,14 @@ func (c *Client) ConnectFromConfig(ctx context.Context, config *MCPConfig) error
 		// Expand environment variables in server configuration
 		ExpandServerEnvVars(&server)
 
+		// Convert server.Env map to KEY=VALUE slice for the subprocess
+		envSlice := make([]string, 0, len(server.Env))
+		for k, v := range server.Env {
+			envSlice = append(envSlice, k+"="+v)
+		}
+
 		// Create transport for this server
-		transport, err := NewStdioTransport(ctx, server.Command, server.Args, nil)
+		transport, err := NewStdioTransport(ctx, server.Command, server.Args, envSlice)
 		if err != nil {
 			return fmt.Errorf("failed to create transport for server %s: %w", name, err)
 		}


### PR DESCRIPTION
## Problem

`ConnectFromConfig` in `internal/mcp/client.go` calls `ExpandServerEnvVars(&server)` correctly, but then passes `nil` as the `env` argument to `NewStdioTransport`:

```go
transport, err := NewStdioTransport(ctx, server.Command, server.Args, nil)
```

`NewStdioTransport` does `cmd.Env = append(os.Environ(), env...)` — so the `nil` means the `env` map from the config is silently ignored and never set on the subprocess. MCP servers that depend on env vars (e.g. for credentials, connection strings, or `PYTHONPATH`) fail to start with `EOF`.

## Fix

Convert `server.Env` (`map[string]string`) to a `[]string` of `KEY=VALUE` pairs and pass it instead of `nil`:

```go
envSlice := make([]string, 0, len(server.Env))
for k, v := range server.Env {
    envSlice = append(envSlice, k+"="+v)
}
transport, err := NewStdioTransport(ctx, server.Command, server.Args, envSlice)
```

Closes #71