### PR TITLE
fix: don't double-append /v1 when BaseURL already contains a path prefix

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -50,18 +50,6 @@ func NewClient(cfg Config) *Client {
 	}
 }
 
-// chatCompletionURL builds the chat completions endpoint from BaseURL.
-// It strips a trailing /v1 from BaseURL before appending /v1/chat/completions,
-// so both plain bases (http://localhost:8080) and bases that already include
-// the version segment (http://localhost:8080/v1) produce the correct URL,
-// and providers with a non-standard path prefix (https://api.z.ai/api/coding/paas/v4)
-// are not broken by a spurious extra /v1.
-func (c *Client) chatCompletionURL() string {
-	base := strings.TrimSuffix(c.cfg.BaseURL, "/")
-	base = strings.TrimSuffix(base, "/v1")
-	return base + "/v1/chat/completions"
-}
-
 // ChatCompletion sends a chat prompt to the OpenAI-compatible endpoint.
 func (c *Client) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (*ChatCompletionResponse, error) {
 	if c.getBackend() == BackendUnknown || (c.getBackend() == BackendLlamaCPP && c.ContextSize() == -1) {
@@ -77,7 +65,7 @@ func (c *Client) ChatCompletion(ctx context.Context, req ChatCompletionRequest) 
 		return nil, err
 	}
 
-	url := c.chatCompletionURL()
+	url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
@@ -129,7 +117,7 @@ func (c *Client) ChatCompletionStream(ctx context.Context, req ChatCompletionReq
 			return
 		}
 
-		url := c.chatCompletionURL()
+		url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/chat/completions"
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 		if err != nil {
 			errCh <- err
@@ -371,6 +359,7 @@ func (c *Client) marshalFlattened(req ChatCompletionRequest) ([]byte, error) {
 
 	return json.Marshal(m)
 }
+
 func (c *Client) formatError(resp *http.Response) error {
 	var apiErr APIErrorResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && apiErr.Error.Message != "" {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +51,20 @@ func NewClient(cfg Config) *Client {
 	}
 }
 
+// chatCompletionURL builds the chat completions endpoint from BaseURL.
+// If the base URL has no path (e.g. "http://localhost:8080"), /v1 is
+// appended automatically for backwards compatibility. If a path is already
+// present (e.g. "https://api.z.ai/api/coding/paas/v4"), it is used as-is
+// and only /chat/completions is appended — consistent with the OpenAI SDK
+// convention that base_url is a true base the caller controls.
+func (c *Client) chatCompletionURL() string {
+	base := strings.TrimSuffix(c.cfg.BaseURL, "/")
+	if u, err := url.Parse(base); err == nil && (u.Path == "" || u.Path == "/") {
+		base += "/v1"
+	}
+	return base + "/chat/completions"
+}
+
 // ChatCompletion sends a chat prompt to the OpenAI-compatible endpoint.
 func (c *Client) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (*ChatCompletionResponse, error) {
 	if c.getBackend() == BackendUnknown || (c.getBackend() == BackendLlamaCPP && c.ContextSize() == -1) {
@@ -65,7 +80,7 @@ func (c *Client) ChatCompletion(ctx context.Context, req ChatCompletionRequest) 
 		return nil, err
 	}
 
-	url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/chat/completions"
+	url := c.chatCompletionURL()
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
@@ -117,7 +132,7 @@ func (c *Client) ChatCompletionStream(ctx context.Context, req ChatCompletionReq
 			return
 		}
 
-		url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/chat/completions"
+		url := c.chatCompletionURL()
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 		if err != nil {
 			errCh <- err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -50,6 +50,18 @@ func NewClient(cfg Config) *Client {
 	}
 }
 
+// chatCompletionURL builds the chat completions endpoint from BaseURL.
+// It strips a trailing /v1 from BaseURL before appending /v1/chat/completions,
+// so both plain bases (http://localhost:8080) and bases that already include
+// the version segment (http://localhost:8080/v1) produce the correct URL,
+// and providers with a non-standard path prefix (https://api.z.ai/api/coding/paas/v4)
+// are not broken by a spurious extra /v1.
+func (c *Client) chatCompletionURL() string {
+	base := strings.TrimSuffix(c.cfg.BaseURL, "/")
+	base = strings.TrimSuffix(base, "/v1")
+	return base + "/v1/chat/completions"
+}
+
 // ChatCompletion sends a chat prompt to the OpenAI-compatible endpoint.
 func (c *Client) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (*ChatCompletionResponse, error) {
 	if c.getBackend() == BackendUnknown || (c.getBackend() == BackendLlamaCPP && c.ContextSize() == -1) {
@@ -65,7 +77,7 @@ func (c *Client) ChatCompletion(ctx context.Context, req ChatCompletionRequest) 
 		return nil, err
 	}
 
-	url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/v1/chat/completions"
+	url := c.chatCompletionURL()
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
@@ -117,7 +129,7 @@ func (c *Client) ChatCompletionStream(ctx context.Context, req ChatCompletionReq
 			return
 		}
 
-		url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/v1/chat/completions"
+		url := c.chatCompletionURL()
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 		if err != nil {
 			errCh <- err


### PR DESCRIPTION
## Problem

`openai_base_url` in `config.json` does not support non-standard API path prefixes because `internal/client/client.go` unconditionally appends `/v1/chat/completions` to whatever base URL is configured:

```go
url := strings.TrimSuffix(c.cfg.BaseURL, "/") + "/v1/chat/completions"
```

Providers that use a versioned or namespaced base path (e.g. `https://api.z.ai/api/coding/paas/v4`) end up with a doubled path:

```
https://api.z.ai/api/coding/paas/v4/v1/chat/completions  → 404
```

## Fix

Introduce a `chatCompletionURL()` helper that parses the base URL and applies the following logic — consistent with the [OpenAI Python SDK convention](https://github.com/openai/openai-python/blob/main/src/openai/_base_client.py) that `base_url` is a true base the caller controls:

- If the base URL has **no path** (e.g. `http://localhost:8080`), `/v1` is appended automatically for backwards compatibility.
- If the base URL **already has a path** (e.g. `https://api.z.ai/api/coding/paas/v4`), it is used as-is and only `/chat/completions` is appended.

```go
func (c *Client) chatCompletionURL() string {
    base := strings.TrimSuffix(c.cfg.BaseURL, "/")
    if u, err := url.Parse(base); err == nil && (u.Path == "" || u.Path == "/") {
        base += "/v1"
    }
    return base + "/chat/completions"
}
```

This correctly handles all common cases:

| `openai_base_url` | Result |
|---|---|
| `http://localhost:8080` | `http://localhost:8080/v1/chat/completions` ✓ |
| `http://localhost:8080/v1` | `http://localhost:8080/v1/chat/completions` ✓ |
| `https://api.z.ai/api/coding/paas/v4` | `https://api.z.ai/api/coding/paas/v4/chat/completions` ✓ |

Closes #72