### PR TITLE
fix: raise MCP truncation limit to 32,768 chars and fix UTF-8 slicing

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -77,10 +77,13 @@ func (t *ToolAdapter) Execute(ctx context.Context, args json.RawMessage) (string
 
 	output := sb.String()
 
-	// Truncate to ~1k tokens (~4000 chars)
-	const maxChars = 4000
-	if len(output) > maxChars {
-		output = output[:maxChars] + "\n\n[... truncated, output exceeded limit ...]"
+	// Truncate to 32,768 Unicode characters — matching the built-in tool limit
+	// (maxReadFileChars / maxBashOutputChars in internal/tool/implementations.go).
+	// Slicing by rune rather than byte prevents splitting multi-byte UTF-8 sequences.
+	const maxChars = 32768
+	runes := []rune(output)
+	if len(runes) > maxChars {
+		output = string(runes[:maxChars]) + "\n\n[... truncated, output exceeded limit ...]"
 	}
 
 	return output, nil

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// truncateOutput replicates the truncation logic in ToolAdapter.Execute so it
+// can be tested independently without a live MCP server.
+func truncateOutput(output string) string {
+	const maxChars = 32768
+	runes := []rune(output)
+	if len(runes) > maxChars {
+		return string(runes[:maxChars]) + "\n\n[... truncated, output exceeded limit ...]"
+	}
+	return output
+}
+
+func TestTruncateOutput_UnderLimit(t *testing.T) {
+	input := strings.Repeat("a", 100)
+	got := truncateOutput(input)
+	if got != input {
+		t.Errorf("expected output to pass through unchanged, got len=%d", len(got))
+	}
+}
+
+func TestTruncateOutput_AtLimit(t *testing.T) {
+	input := strings.Repeat("a", 32768)
+	got := truncateOutput(input)
+	if got != input {
+		t.Errorf("expected output at exactly the limit to pass through unchanged")
+	}
+}
+
+func TestTruncateOutput_OverLimit(t *testing.T) {
+	input := strings.Repeat("a", 32769)
+	got := truncateOutput(input)
+	if !strings.HasSuffix(got, "\n\n[... truncated, output exceeded limit ...]") {
+		t.Errorf("expected truncation marker at end of output, got: %q", got[len(got)-50:])
+	}
+	runes := []rune(got)
+	// Should be exactly maxChars runes plus the marker
+	marker := "\n\n[... truncated, output exceeded limit ...]"
+	content := string(runes[:len(runes)-len([]rune(marker))])
+	if len([]rune(content)) != 32768 {
+		t.Errorf("expected 32768 content runes before marker, got %d", len([]rune(content)))
+	}
+}
+
+// TestTruncateOutput_MultibyteUTF8 verifies that truncation never splits a
+// multi-byte UTF-8 character. Each '日' is 3 bytes; byte-slicing at 32768
+// would produce invalid UTF-8 if the boundary falls inside a character.
+func TestTruncateOutput_MultibyteUTF8(t *testing.T) {
+	// Build a string of 32769 Japanese characters (each 3 bytes = 98307 bytes total).
+	input := strings.Repeat("日", 32769)
+	got := truncateOutput(input)
+
+	// Must be valid UTF-8
+	if !strings.ContainsRune(got, '日') {
+		t.Error("truncated output contains no valid Japanese characters")
+	}
+
+	// The truncated portion must end with the marker, not a broken character
+	if !strings.HasSuffix(got, "\n\n[... truncated, output exceeded limit ...]") {
+		t.Error("expected truncation marker after multi-byte content")
+	}
+
+	// Verify the result decodes cleanly — if any rune is utf8.RuneError it was split
+	for i, r := range got {
+		if r == '�' {
+			t.Errorf("invalid UTF-8 rune at position %d — character was split at boundary", i)
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The `Execute` method on `ToolAdapter` (`internal/mcp/client.go`) hard-caps MCP tool responses at 4,000 bytes while the built-in tools (`read_file`, `bash`) use 32,768 chars (defined in `internal/tool/implementations.go:231-234`). This 8x discrepancy causes legitimate MCP responses (GitHub issues, PR diffs, search results) to be truncated mid-string.

The current 4,000-byte cap on MCP tool responses actually hurts Late's context discipline rather than helping it. Truncated partial data wastes context tokens on garbled information the model can't act on, often triggering retries that further pollute the context window — the exact noise Late's architecture is designed to eliminate. The built-in tools already established 32,768 as the correct limit; MCP tools should match since they surface the same kind of data through a different transport. This fix also corrects a UTF-8 bug where byte-based slicing could split multi-byte characters.

## Changes (`internal/mcp/client.go`)

1. **Raise `maxChars` from 4000 to 32768** to match the built-in tool limit.
2. **Fix UTF-8 bug**: `output[:maxChars]` sliced by bytes, which can corrupt multi-byte characters (e.g. Japanese, emoji). Now converts to `[]rune` before slicing and back to `string` after:
   ```go
   runes := []rune(output)
   if len(runes) > maxChars {
       output = string(runes[:maxChars]) + "\n\n[... truncated, output exceeded limit ...]"
   }
   ```
3. **Fix the comment**: said `"~4000 chars"` but `len()` counts bytes. Updated to accurately describe what the limit does.

## Tests (`internal/mcp/client_test.go`)

Four cases covering the assignment requirements:

- Output under the limit passes through unchanged
- Output at exactly the limit passes through unchanged
- Output over the limit is truncated with the marker appended
- Multi-byte UTF-8 characters (Japanese `日`, 3 bytes each) at the boundary are not split — the test checks for `utf8.RuneError` (`'�'`) in the output

Closes #76