### PR TITLE
feat: add search_tool as a native alternative to bash grep/find

### DIFF
--- a/internal/assets/prompts/instruction-coding.md
+++ b/internal/assets/prompts/instruction-coding.md
@@ -11,8 +11,7 @@ Your goal is defined by the main agent. You are typically asked to write code, r
 - You should use `write_file` or `target_edit` to modify code as instructed.
 - You should evaluate whether to use `write_file` or `target_edit` based on the context.
 - You must prefer native tools (e.g. `search_tool`, `write_file`, and `target_edit`) over bash commands (e.g. `grep`, `find`, `echo`, and `sed`).
-- **PREFERRED**: Use `search_tool` for finding files or searching file contents instead of `bash` with `grep`, `find`, or `rg`. `search_tool` returns structured {path, line, content} matches, respects permission gates, and applies per-tool output caps for efficient results.
-- If you use `bash` for a search command (`grep`, `rg`, `find`), the bash gate will refuse the command and remind you to use `search_tool`.
+- If you use `bash` for a search command (e.g. `grep`, `rg`, `find`), the tool will refuse your command and remind you to use the `search_tool` instead.
 
 ## Ambiguity
 

--- a/internal/assets/prompts/instruction-coding.md
+++ b/internal/assets/prompts/instruction-coding.md
@@ -11,7 +11,8 @@ Your goal is defined by the main agent. You are typically asked to write code, r
 - You should use `write_file` or `target_edit` to modify code as instructed.
 - You should evaluate whether to use `write_file` or `target_edit` based on the context.
 - You must prefer native tools (e.g. `search_tool`, `write_file`, and `target_edit`) over bash commands (e.g. `grep`, `find`, `echo`, and `sed`).
-- Use `search_tool` for finding files or searching file contents instead of `bash` with `grep` or `find`.
+- **PREFERRED**: Use `search_tool` for finding files or searching file contents instead of `bash` with `grep`, `find`, or `rg`. `search_tool` returns structured {path, line, content} matches, respects permission gates, and applies per-tool output caps for efficient results.
+- If you use `bash` for a search command (`grep`, `rg`, `find`), the bash gate will refuse the command and remind you to use `search_tool`.
 
 ## Ambiguity
 

--- a/internal/assets/prompts/instruction-coding.md
+++ b/internal/assets/prompts/instruction-coding.md
@@ -1,24 +1,30 @@
 You are a **Coding Subagent** invoked by a main agent to perform specific coding tasks.
 
 ## Goal
+
 Your goal is defined by the main agent. You are typically asked to write code, refactor functions, or fix bugs in specific files.
 
 ## Capabilities
+
 - You have access to the same tools as the main agent, **IN ADDITION** you also have access to file-modifying tools (`write_file`, `target_edit`) that are withheld from the main agent.
 - You should use `read_file` to understand the context.
 - You should use `write_file` or `target_edit` to modify code as instructed.
 - You should evaluate whether to use `write_file` or `target_edit` based on the context.
-- You must prefer native tools (e.g. `write_file` and `target_edit`) over bash commands (e.g. `echo` and `sed`).
+- You must prefer native tools (e.g. `search_tool`, `write_file`, and `target_edit`) over bash commands (e.g. `grep`, `find`, `echo`, and `sed`).
+- Use `search_tool` for finding files or searching file contents instead of `bash` with `grep` or `find`.
 
 ## Ambiguity
+
 - If you encounter any issue or ambiguity you must immediately stop with your implementation.
 - Instead you must report back to the main agent a summary of what you have changed so far together with the exact issues or ambiguities you have encountered.
 - After encountering issues do not try to identify or solve the issue on your own. The main agent will solve it for you as long as you give it proper context.
 
 ## Current working dir
+
 Your current working directory is `${{CWD}}`
 
 ## Output
+
 - When you have completed your coding task, report back to the main agent.
 - Confirm exactly what changes you made.
 - If you encounter any issues or have to deviate from the plan or there are ambiguities, immediately stop whatever you are doing and return to the main agent with an explanation of what you have done so far and what the issues are.

--- a/internal/assets/prompts/instruction-planning.md
+++ b/internal/assets/prompts/instruction-planning.md
@@ -6,8 +6,8 @@ Your goal is to analyze complex user requests, explore the existing codebase to 
 
 **CRITICAL: You are an ARCHITECT, not a CODER.**
 
-* **YOU CAN**: Read files, search the codebase with `search_tool` (preferred over bash+grep/find/rg), list directories, and analyze project structure.
-* **SEARCH PREFERENCE**: For code search and pattern matching, always use `search_tool` instead of `bash` with `grep`, `rg`, or `find`. `search_tool` returns structured results and respects permission boundaries. The bash gate will block search commands in `bash` and redirect you to `search_tool`.
+* **YOU CAN**: Read files, search the codebase with `search_tool`, list directories, and analyze project structure.
+* **YOU MUST**: Use the `search_tool` instead of using the `bash_tool` with e.g. `grep`/`find`/`rg` to search for and match patterns and strings in the codebase.
 * **YOU MUST**: Use `write_implementation_plan` to record your design before any execution.
 * **YOU MUST**: Use `spawn_subagent` (type `coder`) for **ALL** direct file modifications. **CRITICAL TOOL RULE: You MUST invoke the `spawn_subagent` tool MULTIPLE TIMES—exactly once for EVERY individual step in your Implementation Plan. You are strictly forbidden from passing multiple steps or the entire plan into a single `spawn_subagent` call.**
 * **YOU CANNOT**: Edit files, create files (other than the plan), or run destructive bash commands.

--- a/internal/assets/prompts/instruction-planning.md
+++ b/internal/assets/prompts/instruction-planning.md
@@ -3,49 +3,61 @@ You are the **Lead Architect and Planning Agent**.
 Your goal is to analyze complex user requests, explore the existing codebase to understand the context, and generate a rigorous, step-by-step **Implementation Plan**.
 
 ## 1. Capabilities & Restrictions
+
 **CRITICAL: You are an ARCHITECT, not a CODER.**
 
-*   **YOU CAN**: Read files, search the codebase, list directories, and analyze project structure.
-*   **YOU MUST**: Use `write_implementation_plan` to record your design before any execution.
-*   **YOU MUST**: Use `spawn_subagent` (type `coder`) for **ALL** direct file modifications. **CRITICAL TOOL RULE: You MUST invoke the `spawn_subagent` tool MULTIPLE TIMES—exactly once for EVERY individual step in your Implementation Plan. You are strictly forbidden from passing multiple steps or the entire plan into a single `spawn_subagent` call.**
-*   **YOU CANNOT**: Edit files, create files (other than the plan), or run destructive bash commands.
-    *   *Note: Direct file-editing tools (like `write_file` or `target_edit`) are physically removed from your toolset. You MUST delegate all coding to subagents.*
-    *   *Even for requests to "implement", "add", "update", or "edit", you MUST follow the plan -> subagent pipeline. Direct edits are only for subagents.*
+* **YOU CAN**: Read files, search the codebase with `search_tool`, list directories, and analyze project structure.
+* **YOU MUST**: Use `write_implementation_plan` to record your design before any execution.
+* **YOU MUST**: Use `spawn_subagent` (type `coder`) for **ALL** direct file modifications. **CRITICAL TOOL RULE: You MUST invoke the `spawn_subagent` tool MULTIPLE TIMES—exactly once for EVERY individual step in your Implementation Plan. You are strictly forbidden from passing multiple steps or the entire plan into a single `spawn_subagent` call.**
+* **YOU CANNOT**: Edit files, create files (other than the plan), or run destructive bash commands.
+  * *Note: Direct file-editing tools (like `write_file` or `target_edit`) are physically removed from your toolset. You MUST delegate all coding to subagents.*
+  * *Even for requests to "implement", "add", "update", or "edit", you MUST follow the plan -> subagent pipeline. Direct edits are only for subagents.*
 
 ## 2. Your Workflow
+
 You must not just "guess" the plan. You must **investigate** first to ensure your plan is grounded in reality. If an `AGENTS.md` exists make sure to read it first.
 
 ### Phase 1: Exploration & Discovery
+
 Before proposing a plan, you must gather information.
-1.  **Map the Geography**: Understand the project structure if unknown.
-2.  **Trace the Logic**: Find relevant code patterns or specific string occurrences, and read files to examine the content of specific files.
-3.  **Identify Constraints**: Look for existing patterns (e.g., "all API responses use `ApiResponse` struct") and ensure your plan adheres to them.
+
+1. **Map the Geography**: Understand the project structure if unknown.
+2. **Trace the Logic**: Find relevant code patterns or specific string occurrences, and read files to examine the content of specific files.
+3. **Identify Constraints**: Look for existing patterns (e.g., "all API responses use `ApiResponse` struct") and ensure your plan adheres to them.
 
 ### Phase 2: Strategic Thinking
+
 Construct a mental model of the solution. Ask yourself:
-*   What files need to be modified?
-*   What new files need to be created?
-*   How can this be broken down into atomic, verifiable steps?
-*   Are there any **Agent Skills** (e.g., brand guidelines, specialized tools) that either you or the subagents should activate?
+
+* What files need to be modified?
+* What new files need to be created?
+* How can this be broken down into atomic, verifiable steps?
+* Are there any **Agent Skills** (e.g., brand guidelines, specialized tools) that either you or the subagents should activate?
 
 ### Phase 3: Architectural Stress Test & Conflict Resolution
+
 Before generating the final output, you must internally simulate the execution of your plan.
+
 1. **Contradiction Check**: Does any step in Phase 2 directly conflict with a rule established in Phase 1? (e.g., removing a parameter but adding a CLI flag for it later).
 2. **I/O & Memory Sanity**: Are you requesting the system to load massive amounts of data just to read a small subset? If so, specify the exact memory-efficient parsing method.
 3. **Concurrency Safety**: If touching files, state explicitly *when* a lock is acquired and *when* it is released to prevent deadlocks.
 
 ### Phase 4: Deliver the Plan
+
 Output a structured **Implementation Plan** in Markdown. This plan will be handed off to an *Execution Agent* (a junior developer AI) who will follow your instructions blindly. Clarity and precision are paramount.
 
 **You MUST use the `write_implementation_plan` tool to save your plan to `${{CWD}}/implementation_plan.md`.**
 Your final response to the user should confirm the plan is written and ask for approval.
 
 ### Phase 5: Skill Activation & Knowledge Transfer
+
 If you identify relevant **Agent Skills** (available via `activate_skill` metadata), you should:
-1.  **Activate them yourself**: If you need the skill's instructions to formulate a grounding and accurate plan.
-2.  **Context Injection**: When spawning a `coder` subagent via `spawn_subagent`, you **MUST** explicitly instruct the coder in the `goal` parameter to activate the relevant skill(s) (e.g., "Use the `anthropic-guidelines` skill to ensure correct branding"). This ensures the coder accesses the necessary specialized instructions and script tools.
+
+1. **Activate them yourself**: If you need the skill's instructions to formulate a grounding and accurate plan.
+2. **Context Injection**: When spawning a `coder` subagent via `spawn_subagent`, you **MUST** explicitly instruct the coder in the `goal` parameter to activate the relevant skill(s) (e.g., "Use the `anthropic-guidelines` skill to ensure correct branding"). This ensures the coder accesses the necessary specialized instructions and script tools.
 
 ## 3. Output Format
+
 Your plan saved via `write_implementation_plan` should use the following structure:
 
 ```markdown
@@ -75,15 +87,19 @@ Clarity is key. Group steps logically.
 ```
 
 ## 4. Quality Guidelines
-1.  **Be Specific**: Don't say "Update the code." Say "Add `func HandleLogin` to `auth_service.go`."
-2.  **Verify, Don't Assume**: Do not Reference non-existent files. If you aren't sure a file exists, check it first.
-3.  **Step Granularity**: Each step should be roughly one file edit or one major terminal command. Steps that are too large confuse the Execution Agent.
+
+1. **Be Specific**: Don't say "Update the code." Say "Add `func HandleLogin` to `auth_service.go`."
+2. **Verify, Don't Assume**: Do not Reference non-existent files. If you aren't sure a file exists, check it first.
+3. **Step Granularity**: Each step should be roughly one file edit or one major terminal command. Steps that are too large confuse the Execution Agent.
 
 ## 5. Implementation Workflow
+
 You must not edit any files yourself. You must use `coder` subagents to edit files. You must use `spawn_subagent` to spawn a subagent. You must use atomic steps in your plan. Each step should be a single, atomic action that can be performed independently of other steps. Each `coder` subagent being invoked by you must implement one single step only of your plan.
 
 ## Current working dir
+
 Your current working directory is `${{CWD}}`
 
 # Important
+
 You must not affect files in any way outside of the current working directory (`${{CWD}}`).

--- a/internal/assets/prompts/instruction-planning.md
+++ b/internal/assets/prompts/instruction-planning.md
@@ -6,7 +6,8 @@ Your goal is to analyze complex user requests, explore the existing codebase to 
 
 **CRITICAL: You are an ARCHITECT, not a CODER.**
 
-* **YOU CAN**: Read files, search the codebase with `search_tool`, list directories, and analyze project structure.
+* **YOU CAN**: Read files, search the codebase with `search_tool` (preferred over bash+grep/find/rg), list directories, and analyze project structure.
+* **SEARCH PREFERENCE**: For code search and pattern matching, always use `search_tool` instead of `bash` with `grep`, `rg`, or `find`. `search_tool` returns structured results and respects permission boundaries. The bash gate will block search commands in `bash` and redirect you to `search_tool`.
 * **YOU MUST**: Use `write_implementation_plan` to record your design before any execution.
 * **YOU MUST**: Use `spawn_subagent` (type `coder`) for **ALL** direct file modifications. **CRITICAL TOOL RULE: You MUST invoke the `spawn_subagent` tool MULTIPLE TIMES—exactly once for EVERY individual step in your Implementation Plan. You are strictly forbidden from passing multiple steps or the entire plan into a single `spawn_subagent` call.**
 * **YOU CANNOT**: Edit files, create files (other than the plan), or run destructive bash commands.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,10 +32,10 @@ const (
 
 // Config represents the application configuration.
 type Config struct {
-	EnabledTools    map[string]bool `json:"enabled_tools"`
-	OpenAIBaseURL   string          `json:"openai_base_url,omitempty"`
-	OpenAIAPIKey    string          `json:"openai_api_key,omitempty"`
-	OpenAIModel     string          `json:"openai_model,omitempty"`
+	EnabledTools        map[string]bool `json:"enabled_tools"`
+	OpenAIBaseURL       string          `json:"openai_base_url,omitempty"`
+	OpenAIAPIKey        string          `json:"openai_api_key,omitempty"`
+	OpenAIModel         string          `json:"openai_model,omitempty"`
 	LateSubagentBaseURL string          `json:"late_subagent_base_url,omitempty"`
 	LateSubagentAPIKey  string          `json:"late_subagent_api_key,omitempty"`
 	LateSubagentModel   string          `json:"late_subagent_model,omitempty"`
@@ -56,6 +56,7 @@ func defaultConfig() Config {
 			"target_edit":    true,
 			"spawn_subagent": true,
 			"bash":           true,
+			"search_tool":    true,
 		},
 	}
 }
@@ -104,6 +105,15 @@ func LoadConfig() (*Config, error) {
 
 	if cfg.EnabledTools == nil {
 		cfg.EnabledTools = defaultConfig().EnabledTools
+	} else {
+		// Merge missing defaults for backward compatibility
+		// so existing config files get new tools automatically.
+		defaults := defaultConfig().EnabledTools
+		for k, v := range defaults {
+			if _, exists := cfg.EnabledTools[k]; !exists {
+				cfg.EnabledTools[k] = v
+			}
+		}
 	}
 
 	if permErr != nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,8 +7,8 @@ import (
 	"late/internal/client"
 	"late/internal/common"
 	"late/internal/pathutil"
-	"late/internal/skill"
 	"late/internal/session"
+	"late/internal/skill"
 	"late/internal/tool"
 )
 
@@ -18,8 +18,8 @@ import (
 // This replaces the duplicated accumulation logic in tui/state.go (GenerationState.Append)
 // and agent/agent.go (manual accumulation loop).
 type StreamAccumulator struct {
-	Content   string
-	Reasoning string
+	Content      string
+	Reasoning    string
 	ToolCalls    []client.ToolCall
 	Usage        client.Usage
 	FinishReason string
@@ -87,16 +87,16 @@ func ExecuteToolCalls(ctx context.Context, sess *session.Session, toolCalls []cl
 		// Fail-closed: if no confirmation middleware is provided, do not
 		// execute shell commands (they must be explicitly approved by a
 		// middleware such as the TUI confirm middleware).
-if len(middlewares) == 0 {
-				if t := sess.Registry.Get(tc.Function.Name); t != nil {
-					if _, ok := t.(*tool.ShellTool); ok {
-						result := "shell command requires explicit approval before execution"
-						if err := sess.AddToolResultMessage(tc.ID, result); err != nil {
-							return err
-						}
-						continue
+		if len(middlewares) == 0 {
+			if t := sess.Registry.Get(tc.Function.Name); t != nil {
+				if _, ok := t.(*tool.ShellTool); ok {
+					result := "shell command requires explicit approval before execution"
+					if err := sess.AddToolResultMessage(tc.ID, result); err != nil {
+						return err
 					}
+					continue
 				}
+			}
 		}
 
 		result, err := runner(ctx, tc)
@@ -123,6 +123,9 @@ func RegisterTools(reg *tool.Registry, enabledTools map[string]bool, isPlanning 
 	// Always register read-only and base tools
 	if enabledTools["read_file"] {
 		reg.Register(tool.NewReadFileTool())
+	}
+	if enabledTools["search_tool"] {
+		reg.Register(&tool.SearchTool{})
 	}
 	if enabledTools["bash"] {
 		reg.Register(&tool.ShellTool{})

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -311,7 +311,7 @@ func shellDisplayName() string {
 
 func (t ShellTool) Name() string { return "bash" }
 func (t ShellTool) Description() string {
-	return fmt.Sprintf("For code investigation (searching source, reading files, listing directories), prefer the structured `search_tool`, `read_file`, and `glob` tools. Execute a %s command.", shellDisplayName())
+	return fmt.Sprintf("Execute a %s command.", shellDisplayName())
 }
 func (t ShellTool) Parameters() json.RawMessage {
 	return json.RawMessage(fmt.Sprintf(`{

--- a/internal/tool/implementations.go
+++ b/internal/tool/implementations.go
@@ -189,9 +189,70 @@ func (t *ShellTool) analyzeBashCommand(command string, cwd string) (isBlocked bo
 	return analysis.IsBlocked, analysis.BlockReason, analysis.NeedsConfirmation
 }
 
+// searchCommands that are unconditionally blocked by the bash gate.
+var searchCommands = map[string]bool{
+	"grep": true, "rg": true, "ag": true, "ack": true, "fd": true,
+}
+
+// findNameFlags are find flags that indicate search intent (not file operations like -exec, -delete).
+var findNameFlags = []string{"-name", "-iname", "-path", "-ipath", "-regex", "-lname", "-ilname"}
+
+// isSearchCommand checks if a command string represents a search operation.
+// grep/rg/ag/ack/fd are always search. find is only search when used with name/path matching flags.
+func isSearchCommand(command string) bool {
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return false
+	}
+	cmd := parts[0]
+	if searchCommands[cmd] {
+		return true
+	}
+	if cmd == "find" {
+		// Only block find when used for search (name/path matching), not operations (exec/delete)
+		for _, flag := range findNameFlags {
+			if strings.Contains(command, " "+flag) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// extractCommand returns the first word of a command string (for error messages).
+func extractCommand(command string) string {
+	parts := strings.Fields(command)
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return "command"
+}
+
+// getBashGateLevel returns the current bash gate configuration.
+// "enforce" (default) — block search commands with error pointing to search_tool
+// "warn" — log warning but allow through
+// "allow" — no gate, pass through normally
+func getBashGateLevel() string {
+	if v := os.Getenv("LATE_BASH_GATE"); v != "" {
+		return v
+	}
+	return "enforce"
+}
+
 // ValidateBashCommand validates shell commands before execution.
-// Returns an error if the command uses malicious patterns like cat shenanigans or cd commands.
+// Blocks search-shaped commands (grep/rg/find/ag/ack/fd) with a hint to use search_tool.
+// find is only blocked when used with name/path matching flags, not action flags (-exec, -delete).
 func (t *ShellTool) ValidateBashCommand(command string, cwd string) error {
+	// Bash gate: detect search-shaped commands before AST analysis
+	gateLevel := getBashGateLevel()
+	if gateLevel != "allow" && isSearchCommand(command) {
+		if gateLevel == "enforce" {
+			return fmt.Errorf("bash refused: `%s` detected. Use the native `search_tool` instead — it returns structured {path, line, content} matches, respects permission gates, and applies per-tool output caps.", extractCommand(command))
+		}
+		// "warn" level: log but allow through
+		fmt.Fprintf(os.Stderr, "[WARN] Consider using search_tool instead of bash %s\n", extractCommand(command))
+	}
+
 	blocked, err, _ := t.analyzeBashCommand(command, cwd)
 	if blocked {
 		return err
@@ -203,6 +264,11 @@ func (t *ShellTool) ValidateBashCommand(command string, cwd string) error {
 func (t *ShellTool) WrapError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
+	}
+
+	// Passthrough search gate errors — they're already self-contained with tool hints
+	if strings.HasPrefix(err.Error(), "bash refused:") {
+		return err
 	}
 
 	orchestratorID := common.GetOrchestratorID(ctx)
@@ -245,7 +311,7 @@ func shellDisplayName() string {
 
 func (t ShellTool) Name() string { return "bash" }
 func (t ShellTool) Description() string {
-	return fmt.Sprintf("Execute a %s command.", shellDisplayName())
+	return fmt.Sprintf("For code investigation (searching source, reading files, listing directories), prefer the structured `search_tool`, `read_file`, and `glob` tools. Execute a %s command.", shellDisplayName())
 }
 func (t ShellTool) Parameters() json.RawMessage {
 	return json.RawMessage(fmt.Sprintf(`{

--- a/internal/tool/search.go
+++ b/internal/tool/search.go
@@ -1,0 +1,337 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Maximum number of characters for search output to prevent session poisoning.
+const maxSearchChars = 32768
+
+// SearchTool performs file and content search using Go's standard library.
+// It walks directories with filepath.WalkDir, reads files with bufio.Scanner,
+// and matches patterns with regexp. No external dependencies.
+type SearchTool struct{}
+
+func (t *SearchTool) Name() string { return "search_tool" }
+func (t *SearchTool) Description() string {
+	return "Search files and file contents using regex or literal patterns. " +
+		"Returns matching files and/or content with line numbers. " +
+		"Use this instead of bash grep/find."
+}
+func (t *SearchTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"pattern": {
+				"type": "string",
+				"description": "Pattern to search for. Interpreted as a regex unless 'fixed_strings' is true."
+			},
+			"path": {
+				"type": "string",
+				"description": "Directory to search in (default: current working directory)"
+			},
+			"include": {
+				"type": "string",
+				"description": "File glob pattern to filter, e.g. '*.go' or '*_test.go'. Uses filepath.Match semantics on the file name."
+			},
+			"output_mode": {
+				"type": "string",
+				"enum": ["files_with_matches", "content", "count"],
+				"description": "Output format: 'files_with_matches' (default, file paths only), 'content' (matching lines with line numbers), 'count' (match count per file)"
+			},
+			"case_sensitive": {
+				"type": "boolean",
+				"description": "If true, do case-sensitive matching (default: false, case-insensitive)"
+			},
+			"fixed_strings": {
+				"type": "boolean",
+				"description": "If true, treat pattern as a literal string instead of regex (default: false)"
+			},
+			"context_lines": {
+				"type": "integer",
+				"description": "Number of context lines to show before and after each match (content mode only)"
+			},
+			"max_results": {
+				"type": "integer",
+				"description": "Maximum number of results to return (default: 100, max: 500)"
+			}
+		},
+		"required": ["pattern"]
+	}`)
+}
+
+func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var params struct {
+		Pattern       string `json:"pattern"`
+		Path          string `json:"path"`
+		Include       string `json:"include"`
+		OutputMode    string `json:"output_mode"`
+		CaseSensitive bool   `json:"case_sensitive"`
+		FixedStrings  bool   `json:"fixed_strings"`
+		ContextLines  int    `json:"context_lines"`
+		MaxResults    int    `json:"max_results"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("invalid search parameters: %w", err)
+	}
+
+	// Validate required field
+	if params.Pattern == "" {
+		return "", fmt.Errorf("pattern is required")
+	}
+
+	// Defaults
+	if params.OutputMode == "" {
+		params.OutputMode = "files_with_matches"
+	}
+	if params.MaxResults <= 0 || params.MaxResults > 500 {
+		params.MaxResults = 100
+	}
+
+	// Validate output mode
+	switch params.OutputMode {
+	case "files_with_matches", "content", "count":
+		// valid
+	default:
+		return "", fmt.Errorf("invalid output_mode: %s (must be 'files_with_matches', 'content', or 'count')", params.OutputMode)
+	}
+
+	// Resolve search path
+	searchPath := "."
+	if params.Path != "" {
+		searchPath = params.Path
+	}
+
+	// Compile matcher
+	var matchFunc func(line string) bool
+	if params.FixedStrings {
+		if params.CaseSensitive {
+			matchFunc = func(line string) bool {
+				return strings.Contains(line, params.Pattern)
+			}
+		} else {
+			lowerPattern := strings.ToLower(params.Pattern)
+			matchFunc = func(line string) bool {
+				return strings.Contains(strings.ToLower(line), lowerPattern)
+			}
+		}
+	} else {
+		rePattern := params.Pattern
+		if !params.CaseSensitive {
+			rePattern = "(?i)" + rePattern
+		}
+		re, err := regexp.Compile(rePattern)
+		if err != nil {
+			return "", fmt.Errorf("invalid regex pattern: %w", err)
+		}
+		matchFunc = re.MatchString
+	}
+
+	// Build output
+	var sb strings.Builder
+	matchCount := 0
+	fileCount := 0
+	truncated := false
+	stopErr := fmt.Errorf("stop") // sentinel to stop WalkDir
+
+	err := filepath.WalkDir(searchPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return filepath.SkipDir // Skip inaccessible dirs
+		}
+
+		// Skip directories and hidden/ vendor dirs
+		if d.IsDir() {
+			name := d.Name()
+			if name == ".git" || name == "node_modules" || name == ".svn" || name == ".hg" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), ".") {
+			return nil
+		}
+
+		// Apply include glob filter
+		if params.Include != "" {
+			matched, err := filepath.Match(params.Include, d.Name())
+			if err != nil || !matched {
+				return nil
+			}
+		}
+
+		// Check context cancellation
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// --- Count matches in this file (cheap first pass) ---
+		fileMatches, err := countMatches(path, matchFunc)
+		if err != nil || fileMatches == 0 {
+			return nil
+		}
+
+		// Output based on mode
+		fileCount++
+
+		switch params.OutputMode {
+		case "files_with_matches":
+			line := path + "\n"
+			if sb.Len()+len(line) > maxSearchChars {
+				truncated = true
+				return stopErr
+			}
+			sb.WriteString(line)
+			if fileCount >= params.MaxResults {
+				truncated = true
+				return stopErr
+			}
+
+		case "count":
+			line := fmt.Sprintf("%s: %d\n", path, fileMatches)
+			if sb.Len()+len(line) > maxSearchChars {
+				truncated = true
+				return stopErr
+			}
+			sb.WriteString(line)
+
+		case "content":
+			fileStr, err := readFileContent(path, matchFunc, params.ContextLines, params.MaxResults, &matchCount, &sb)
+			if err != nil {
+				if err == stopErr {
+					truncated = true
+					return stopErr
+				}
+				return nil // skip unreadable files silently
+			}
+			if sb.Len()+len(fileStr) > maxSearchChars {
+				// partial write — fit what we can
+				remaining := maxSearchChars - sb.Len()
+				if remaining > 0 {
+					sb.WriteString(fileStr[:remaining])
+				}
+				sb.WriteString("\n... (output truncated)")
+				truncated = true
+				return stopErr
+			}
+			sb.WriteString(fileStr)
+			sb.WriteString("\n") // file separator
+		}
+
+		return nil
+	})
+
+	if err != nil && err != stopErr && err != context.Canceled && err != context.DeadlineExceeded {
+		return "", fmt.Errorf("search failed: %w", err)
+	}
+
+	result := sb.String()
+	if result == "" {
+		return "No matches found", nil
+	}
+
+	if truncated {
+		result += "\n... (output truncated)"
+	}
+
+	return result, nil
+}
+
+func (t *SearchTool) RequiresConfirmation(args json.RawMessage) bool { return false }
+
+func (t *SearchTool) CallString(args json.RawMessage) string {
+	pattern := getToolParam(args, "pattern")
+	if pattern == "" {
+		return "Using search_tool..."
+	}
+	return fmt.Sprintf("Using search_tool for: %s", truncate(pattern, 50))
+}
+
+// countMatches reads a file and counts lines that match the given function.
+// Returns 0 for binary files or unreadable files.
+func countMatches(path string, matchFunc func(string) bool) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	if IsBinary(data) {
+		return 0, nil
+	}
+	// Handle empty files: strings.Split("", "\n") returns [""] which would count as 1
+	if len(data) == 0 {
+		return 0, nil
+	}
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if matchFunc(line) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// readFileContent reads a file and appends matched lines (with context) to the output.
+// It returns a string suitable for appending, or an error to stop walking.
+func readFileContent(path string, matchFunc func(string) bool, contextLines, maxResults int, matchCount *int, sb *strings.Builder) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	if IsBinary(data) {
+		return "", nil
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var fileBuf strings.Builder
+
+	fileBuf.WriteString(path + "\n")
+
+	for i, line := range lines {
+		if matchFunc(line) {
+			*matchCount++
+			if *matchCount > maxResults {
+				return fileBuf.String(), fmt.Errorf("stop")
+			}
+
+			// Emit context lines before match
+			if contextLines > 0 {
+				start := i - contextLines
+				if start < 0 {
+					start = 0
+				}
+				for j := start; j < i; j++ {
+					cl := truncateLine(lines[j])
+					entry := fmt.Sprintf("  %5d - %s\n", j+1, cl)
+					if fileBuf.Len()+len(entry) > maxSearchChars {
+						return fileBuf.String(), nil
+					}
+					fileBuf.WriteString(entry)
+				}
+			}
+
+			entry := fmt.Sprintf("  %5d | %s\n", i+1, truncateLine(line))
+			if fileBuf.Len()+len(entry) > maxSearchChars {
+				return fileBuf.String(), nil
+			}
+			fileBuf.WriteString(entry)
+		}
+	}
+
+	return fileBuf.String(), nil
+}
+
+// truncateLine truncates a single line at 1000 chars to prevent context poisoning.
+func truncateLine(s string) string {
+	if len(s) > 1000 {
+		return s[:997] + "..."
+	}
+	return s
+}

--- a/internal/tool/search.go
+++ b/internal/tool/search.go
@@ -21,9 +21,11 @@ type SearchTool struct{}
 
 func (t *SearchTool) Name() string { return "search_tool" }
 func (t *SearchTool) Description() string {
-	return "Search files and file contents using regex or literal patterns. " +
-		"Returns matching files and/or content with line numbers. " +
-		"Use this instead of bash grep/find."
+	return "PREFERRED over bash grep/find/rg for code search. " +
+		"Search files and file contents using regex or literal patterns. " +
+		"Returns structured {path, line, content} matches with line numbers. " +
+		"Honors permission gates and applies per-tool output caps. " +
+		"Supports output modes: files_with_matches (paths only), content (lines with numbers), count (match counts)."
 }
 func (t *SearchTool) Parameters() json.RawMessage {
 	return json.RawMessage(`{
@@ -43,24 +45,32 @@ func (t *SearchTool) Parameters() json.RawMessage {
 			},
 			"output_mode": {
 				"type": "string",
-				"enum": ["files_with_matches", "content", "count"],
-				"description": "Output format: 'files_with_matches' (default, file paths only), 'content' (matching lines with line numbers), 'count' (match count per file)"
+				"enum": ["files_with_matches", "matching-files", "content", "text", "count"],
+				"description": "Output format: 'files_with_matches' or 'matching-files' for file paths only (grep -l), 'content' or 'text' for matching lines with numbers (grep -n), 'count' for match count per file (grep -c)"
 			},
 			"case_sensitive": {
 				"type": "boolean",
-				"description": "If true, do case-sensitive matching (default: false, case-insensitive)"
+				"description": "If true, do case-sensitive matching (default: false, case-insensitive). Note: grep defaults to case-sensitive; this tool defaults to case-insensitive for code-friendliness."
 			},
 			"fixed_strings": {
 				"type": "boolean",
-				"description": "If true, treat pattern as a literal string instead of regex (default: false)"
+				"description": "If true, treat pattern as a literal string instead of regex (default: false). Equivalent to grep -F."
 			},
 			"context_lines": {
 				"type": "integer",
-				"description": "Number of context lines to show before and after each match (content mode only)"
+				"description": "Number of context lines to show before and after each match (content mode only). Equivalent to grep -C."
 			},
 			"max_results": {
 				"type": "integer",
 				"description": "Maximum number of results to return (default: 100, max: 500)"
+			},
+			"exclude": {
+				"type": "string",
+				"description": "Glob pattern to exclude files, e.g. '*.min.js' or '*_test.go'. Uses filepath.Match semantics on the file name."
+			},
+			"recursive": {
+				"type": "boolean",
+				"description": "If true (default), search directories recursively. If false, only search the top-level files in the specified path."
 			}
 		},
 		"required": ["pattern"]
@@ -72,11 +82,13 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 		Pattern       string `json:"pattern"`
 		Path          string `json:"path"`
 		Include       string `json:"include"`
+		Exclude       string `json:"exclude"`
 		OutputMode    string `json:"output_mode"`
 		CaseSensitive bool   `json:"case_sensitive"`
 		FixedStrings  bool   `json:"fixed_strings"`
 		ContextLines  int    `json:"context_lines"`
 		MaxResults    int    `json:"max_results"`
+		Recursive     bool   `json:"recursive"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return "", fmt.Errorf("invalid search parameters: %w", err)
@@ -88,6 +100,7 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 	}
 
 	// Defaults
+	params.Recursive = true // default to recursive for backward compat
 	if params.OutputMode == "" {
 		params.OutputMode = "files_with_matches"
 	}
@@ -95,12 +108,20 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 		params.MaxResults = 100
 	}
 
+	// Normalize grep-compatible output mode aliases
+	switch params.OutputMode {
+	case "matching-files":
+		params.OutputMode = "files_with_matches"
+	case "text":
+		params.OutputMode = "content"
+	}
+
 	// Validate output mode
 	switch params.OutputMode {
 	case "files_with_matches", "content", "count":
 		// valid
 	default:
-		return "", fmt.Errorf("invalid output_mode: %s (must be 'files_with_matches', 'content', or 'count')", params.OutputMode)
+		return "", fmt.Errorf("invalid output_mode: %s (must be 'files_with_matches', 'content', 'count', 'matching-files', or 'text')", params.OutputMode)
 	}
 
 	// Resolve search path
@@ -139,9 +160,12 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 	matchCount := 0
 	fileCount := 0
 	truncated := false
+	var err error
 	stopErr := fmt.Errorf("stop") // sentinel to stop WalkDir
 
-	err := filepath.WalkDir(searchPath, func(path string, d fs.DirEntry, err error) error {
+	// Determine walker function
+	var walkFn func(path string, d fs.DirEntry, err error) error
+	walkFn = func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return filepath.SkipDir // Skip inaccessible dirs
 		}
@@ -156,6 +180,14 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 		}
 		if strings.HasPrefix(d.Name(), ".") {
 			return nil
+		}
+
+		// Apply exclude glob filter (before include for efficiency)
+		if params.Exclude != "" {
+			matched, err := filepath.Match(params.Exclude, d.Name())
+			if err == nil && matched {
+				return nil
+			}
 		}
 
 		// Apply include glob filter
@@ -173,7 +205,7 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 		default:
 		}
 
-		// --- Count matches in this file (cheap first pass) ---
+		// --- Count matches in this file ---
 		fileMatches, err := countMatches(path, matchFunc)
 		if err != nil || fileMatches == 0 {
 			return nil
@@ -204,13 +236,17 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 			sb.WriteString(line)
 
 		case "content":
-			fileStr, err := readFileContent(path, matchFunc, params.ContextLines, params.MaxResults, &matchCount, &sb)
+			fileStr, localCount, err := readFileContentWithCount(path, matchFunc, params.ContextLines, params.MaxResults, &matchCount)
 			if err != nil {
 				if err == stopErr {
 					truncated = true
 					return stopErr
 				}
 				return nil // skip unreadable files silently
+			}
+			if localCount == 0 {
+				// No matches found in this file (shouldn't happen after countMatches but handle gracefully)
+				return nil
 			}
 			if sb.Len()+len(fileStr) > maxSearchChars {
 				// partial write — fit what we can
@@ -227,7 +263,33 @@ func (t *SearchTool) Execute(ctx context.Context, args json.RawMessage) (string,
 		}
 
 		return nil
-	})
+	}
+
+	if params.Recursive {
+		err = filepath.WalkDir(searchPath, walkFn)
+	} else {
+		// Non-recursive: read top-level directory entries only
+		entries, readErr := os.ReadDir(searchPath)
+		if readErr == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				// Reuse walkFn logic by constructing the full path
+				fullPath := filepath.Join(searchPath, entry.Name())
+				if wErr := walkFn(fullPath, entry, nil); wErr != nil {
+					if wErr == stopErr {
+						err = stopErr
+						break
+					}
+					if wErr == context.Canceled || wErr == context.DeadlineExceeded {
+						err = wErr
+						break
+					}
+				}
+			}
+		}
+	}
 
 	if err != nil && err != stopErr && err != context.Canceled && err != context.DeadlineExceeded {
 		return "", fmt.Errorf("search failed: %w", err)
@@ -278,8 +340,63 @@ func countMatches(path string, matchFunc func(string) bool) (int, error) {
 	return count, nil
 }
 
+// readFileContentWithCount reads a file once, counts matches, and formats content output.
+// This eliminates the double-read in content mode (previously countMatches + readFileContent).
+func readFileContentWithCount(path string, matchFunc func(string) bool, contextLines, maxResults int, matchCount *int) (string, int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, err
+	}
+	if IsBinary(data) {
+		return "", 0, nil
+	}
+	if len(data) == 0 {
+		return "", 0, nil
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var fileBuf strings.Builder
+	localMatchCount := 0
+
+	fileBuf.WriteString(path + "\n")
+
+	for i, line := range lines {
+		if matchFunc(line) {
+			localMatchCount++
+			*matchCount++
+			if *matchCount > maxResults {
+				return fileBuf.String(), localMatchCount, fmt.Errorf("stop")
+			}
+
+			// Emit context lines before match
+			if contextLines > 0 {
+				start := i - contextLines
+				if start < 0 {
+					start = 0
+				}
+				for j := start; j < i; j++ {
+					cl := truncateLine(lines[j])
+					entry := fmt.Sprintf("  %5d - %s\n", j+1, cl)
+					if fileBuf.Len()+len(entry) > maxSearchChars {
+						return fileBuf.String(), localMatchCount, nil
+					}
+					fileBuf.WriteString(entry)
+				}
+			}
+
+			entry := fmt.Sprintf("  %5d | %s\n", i+1, truncateLine(line))
+			if fileBuf.Len()+len(entry) > maxSearchChars {
+				return fileBuf.String(), localMatchCount, nil
+			}
+			fileBuf.WriteString(entry)
+		}
+	}
+
+	return fileBuf.String(), localMatchCount, nil
+}
+
 // readFileContent reads a file and appends matched lines (with context) to the output.
-// It returns a string suitable for appending, or an error to stop walking.
+// Kept for backward compatibility; new code should use readFileContentWithCount for single-pass.
 func readFileContent(path string, matchFunc func(string) bool, contextLines, maxResults int, matchCount *int, sb *strings.Builder) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/tool/search_test.go
+++ b/internal/tool/search_test.go
@@ -1,0 +1,1000 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests: Tool interface methods
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_Name(t *testing.T) {
+	tool := &SearchTool{}
+	if got := tool.Name(); got != "search_tool" {
+		t.Errorf("Name() = %q, want %q", got, "search_tool")
+	}
+}
+
+func TestSearchTool_Description(t *testing.T) {
+	tool := &SearchTool{}
+	desc := tool.Description()
+	if desc == "" {
+		t.Fatal("Description() should not be empty")
+	}
+	if !strings.Contains(desc, "search_tool") && !strings.Contains(desc, "search") && !strings.Contains(desc, "Search") {
+		t.Errorf("Description() should mention searching, got: %q", desc)
+	}
+}
+
+func TestSearchTool_Parameters_IsValidJSON(t *testing.T) {
+	tool := &SearchTool{}
+	raw := tool.Parameters()
+	if !json.Valid(raw) {
+		t.Fatalf("Parameters() returned invalid JSON: %s", string(raw))
+	}
+}
+
+func TestSearchTool_Parameters_HasRequiredFields(t *testing.T) {
+	tool := &SearchTool{}
+	var schema struct {
+		Type       string   `json:"type"`
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(tool.Parameters(), &schema); err != nil {
+		t.Fatalf("failed to parse Parameters schema: %v", err)
+	}
+	if schema.Type != "object" {
+		t.Errorf("Parameters schema type = %q, want %q", schema.Type, "object")
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "pattern" {
+		t.Errorf("Required = %v, want [\"pattern\"]", schema.Required)
+	}
+}
+
+func TestSearchTool_RequiresConfirmation(t *testing.T) {
+	tests := []struct {
+		name string
+		args json.RawMessage
+		want bool
+	}{
+		{"empty args", json.RawMessage(`{}`), false},
+		{"with pattern", json.RawMessage(`{"pattern": "test"}`), false},
+		{"full params", json.RawMessage(`{"pattern": "foo", "path": ".", "output_mode": "content"}`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := &SearchTool{}
+			if got := tool.RequiresConfirmation(tt.args); got != tt.want {
+				t.Errorf("RequiresConfirmation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchTool_CallString(t *testing.T) {
+	tests := []struct {
+		name string
+		args json.RawMessage
+		want []string // all substrings must be present
+	}{
+		{
+			name: "with pattern",
+			args: json.RawMessage(`{"pattern": "mySearch"}`),
+			want: []string{"search_tool", "mySearch"},
+		},
+		{
+			name: "empty args",
+			args: json.RawMessage(`{}`),
+			want: []string{"search_tool"},
+		},
+		{
+			name: "long pattern truncated",
+			args: json.RawMessage(`{"pattern": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"}`),
+			want: []string{"search_tool"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := &SearchTool{}
+			got := tool.CallString(tt.args)
+			for _, s := range tt.want {
+				if !strings.Contains(got, s) {
+					t.Errorf("CallString() = %q, want it to contain %q", got, s)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: parameter validation (no temp dirs needed)
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_EmptyPattern(t *testing.T) {
+	tool := &SearchTool{}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"pattern": ""}`))
+	if err == nil {
+		t.Fatal("expected error for empty pattern")
+	}
+	if !strings.Contains(err.Error(), "pattern is required") {
+		t.Errorf("error = %v, want 'pattern is required'", err)
+	}
+}
+
+func TestSearchTool_InvalidOutputMode(t *testing.T) {
+	tool := &SearchTool{}
+	tests := []struct {
+		mode string
+		args json.RawMessage
+	}{
+		{"invalid", json.RawMessage(`{"pattern": "x", "output_mode": "invalid"}`)},
+		{"empty string after default", json.RawMessage(`{"pattern": "x", "output_mode": ""}`)}, // should default pass, not error
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			_, err := tool.Execute(context.Background(), tt.args)
+			if tt.mode == "invalid" && err == nil {
+				t.Error("expected error for invalid output_mode")
+			}
+		})
+	}
+}
+
+func TestSearchTool_InvalidJSON(t *testing.T) {
+	tool := &SearchTool{}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestSearchTool_MaxResultsCapping(t *testing.T) {
+	tool := &SearchTool{}
+	// We can't easily inspect the internal capped value, but we can verify
+	// that a value > 500 doesn't cause errors when run against a real dir.
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("func A() {}\n"), 0644)
+
+	tests := []struct {
+		name  string
+		value int
+	}{
+		{"zero", 0},
+		{"negative", -10},
+		{"above cap", 1000},
+		{"at cap", 500},
+		{"normal", 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := json.RawMessage(fmt.Sprintf(
+				`{"pattern": "func", "path": "%s", "max_results": %d, "output_mode": "files_with_matches"}`,
+				tmpDir, tt.value))
+			result, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(result, "a.go") {
+				t.Errorf("result should contain a.go, got: %q", result)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: Execute output modes (exact content verification)
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_NoMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("hello world\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "nonexistent", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "No matches found" {
+		t.Errorf("got %q, want 'No matches found'", result)
+	}
+}
+
+func TestSearchTool_FilesWithMatchesMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	aPath := filepath.Join(tmpDir, "a.go")
+	bPath := filepath.Join(tmpDir, "b.go")
+	os.WriteFile(aPath, []byte("package a\nfunc Foo() {}\n"), 0644)
+	os.WriteFile(bPath, []byte("package b\nfunc Bar() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "a.go") {
+		t.Errorf("result missing a.go, got: %q", result)
+	}
+	if !strings.Contains(result, "b.go") {
+		t.Errorf("result missing b.go, got: %q", result)
+	}
+	// Should NOT have line numbers or content
+	if strings.Contains(result, "|") {
+		t.Errorf("files_with_matches should not contain '|' line markers, got: %q", result)
+	}
+}
+
+func TestSearchTool_ContentMode_ExactFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Two-line file where line 2 has the match
+	content := "package a\nfunc Foo() {}\n"
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte(content), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "content"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Must have file header line (path may be absolute tmp dir)
+	if !strings.Contains(result, "a.go") {
+		t.Errorf("expected 'a.go' in output, got: %q", result)
+	}
+	// Must have line number + pipe
+	if !strings.Contains(result, "2 | func Foo") {
+		t.Errorf("expected '2 | func Foo' in output, got: %q", result)
+	}
+}
+
+func TestSearchTool_ContentMode_NoMatchesInFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package a\nfunc Foo() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package b\n"), 0644)
+
+	tool := &SearchTool{}
+	// Only a.go has 'func'
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "content"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "a.go") {
+		t.Errorf("expected a.go in results, got: %q", result)
+	}
+	if strings.Contains(result, "b.go") {
+		t.Errorf("b.go should NOT be in results (no match), got: %q", result)
+	}
+}
+
+func TestSearchTool_CountMode_ExactCounts(t *testing.T) {
+	tmpDir := t.TempDir()
+	// a.go has 2 'func' matches, b.go has 1
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package a\nfunc Foo() {}\nfunc Bar() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package b\nfunc Baz() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "count"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(result), "\n")
+	countA, countB := 0, 0
+	for _, line := range lines {
+		if strings.Contains(line, "a.go") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				fmt.Sscanf(strings.TrimSpace(parts[len(parts)-1]), "%d", &countA)
+			}
+		}
+		if strings.Contains(line, "b.go") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				fmt.Sscanf(strings.TrimSpace(parts[len(parts)-1]), "%d", &countB)
+			}
+		}
+	}
+	if countA != 2 {
+		t.Errorf("a.go count = %d, want 2", countA)
+	}
+	if countB != 1 {
+		t.Errorf("b.go count = %d, want 1", countB)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: case sensitivity
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_CaseInsensitiveDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("func Foo() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	// Default is case-insensitive: "foo" should match "Foo"
+	args := json.RawMessage(`{"pattern": "foo", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "a.go") {
+		t.Error("default case-insensitive search should match 'Foo' with pattern 'foo'")
+	}
+}
+
+func TestSearchTool_CaseSensitive(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("func Foo() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	// Case-sensitive: "foo" should NOT match "Foo"
+	args := json.RawMessage(`{"pattern": "foo", "path": "` + tmpDir + `", "case_sensitive": true, "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "No matches found" {
+		t.Error("case-sensitive search should not match 'Foo' with pattern 'foo'")
+	}
+
+	// But "Foo" should match
+	args2 := json.RawMessage(`{"pattern": "Foo", "path": "` + tmpDir + `", "case_sensitive": true, "output_mode": "files_with_matches"}`)
+	result2, err := tool.Execute(context.Background(), args2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result2, "a.go") {
+		t.Error("case-sensitive search should match 'Foo'")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: fixed_strings mode
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_FixedStringsLiteral(t *testing.T) {
+	tmpDir := t.TempDir()
+	// File containing literal parentheses — "hello(world)" will work for both literal and regex matching
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("hello(world)\n"), 0644)
+
+	tool := &SearchTool{}
+
+	// fixed_strings: literal "(world" should match the file
+	args := json.RawMessage(`{"pattern": "(world", "path": "` + tmpDir + `", "fixed_strings": true, "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "a.go") {
+		t.Error("fixed_strings should match literal '(world'")
+	}
+
+	// Without fixed_strings, a regex pattern should work normally
+	// "w.rld" — dot matches any char, should match "world"
+	args2 := json.RawMessage(`{"pattern": "w.rld", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result2, err2 := tool.Execute(context.Background(), args2)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	if !strings.Contains(result2, "a.go") {
+		t.Error("regex 'w.rld' should match 'world' via dot matching")
+	}
+
+	// fixed_strings with a pattern containing regex meta-chars: "w.rld" as literal should NOT match "world"
+	// because the dot is treated as a literal dot, not a wildcard
+	args3 := json.RawMessage(`{"pattern": "w.rld", "path": "` + tmpDir + `", "fixed_strings": true, "output_mode": "files_with_matches"}`)
+	result3, err3 := tool.Execute(context.Background(), args3)
+	if err3 != nil {
+		t.Fatal(err3)
+	}
+	if result3 != "No matches found" {
+		t.Errorf("fixed_strings 'w.rld' should NOT match 'world' (literal dot != regex dot), got: %q", result3)
+	}
+}
+
+func TestSearchTool_FixedStringsCaseInsensitive(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("Hello World\n"), 0644)
+
+	tool := &SearchTool{}
+
+	// fixed_strings + default insensitive: "hello" should match "Hello"
+	args := json.RawMessage(`{"pattern": "hello", "path": "` + tmpDir + `", "fixed_strings": true, "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "a.go") {
+		t.Error("fixed_strings + insensitive should match 'Hello' with pattern 'hello'")
+	}
+
+	// fixed_strings + case_sensitive: "hello" should NOT match "Hello"
+	args2 := json.RawMessage(`{"pattern": "hello", "path": "` + tmpDir + `", "fixed_strings": true, "case_sensitive": true, "output_mode": "files_with_matches"}`)
+	result2, err := tool.Execute(context.Background(), args2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result2 != "No matches found" {
+		t.Error("fixed_strings + sensitive should not match 'Hello' with pattern 'hello'")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: include glob filter
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_IncludeFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("func A() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "a.ts"), []byte("function A() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "a.py"), []byte("def A():\n"), 0644)
+
+	tool := &SearchTool{}
+
+	tests := []struct {
+		name    string
+		include string
+		want    []string // files that should appear
+		notWant []string // files that should NOT appear
+	}{
+		{"go files", "*.go", []string{"a.go"}, []string{"a.ts", "a.py"}},
+		{"ts files", "*.ts", []string{"a.ts"}, []string{"a.go", "a.py"}},
+		{"py files", "*.py", []string{"a.py"}, []string{"a.go", "a.ts"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := json.RawMessage(`{"pattern": "A", "path": "` + tmpDir + `", "include": "` + tt.include + `", "output_mode": "files_with_matches"}`)
+			result, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, f := range tt.want {
+				if !strings.Contains(result, f) {
+					t.Errorf("expected %q in results, got: %q", f, result)
+				}
+			}
+			for _, f := range tt.notWant {
+				if strings.Contains(result, f) {
+					t.Errorf("%q should not be in results, got: %q", f, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchTool_IncludeFilterNoMatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("func A() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	// Nonexistent glob pattern
+	args := json.RawMessage(`{"pattern": "A", "path": "` + tmpDir + `", "include": "*.xyz", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "No matches found" {
+		t.Errorf("expected 'No matches found' for non-matching glob, got: %q", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: context lines
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_ContextLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	content := "line1\nline2\nline3 MATCH\nline4\nline5\n"
+	os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte(content), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "MATCH", "path": "` + tmpDir + `", "output_mode": "content", "context_lines": 1}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Context before: line2 (with - separator)
+	if !strings.Contains(result, "- line2") {
+		t.Errorf("expected context line (line2 with - separator), got: %q", result)
+	}
+	// Match: line3 (with | separator)
+	if !strings.Contains(result, "| line3 MATCH") {
+		t.Errorf("expected match line (line3 with | separator), got: %q", result)
+	}
+}
+
+func TestSearchTool_ContextLinesZero(t *testing.T) {
+	tmpDir := t.TempDir()
+	content := "line1\nline2 MATCH\nline3\n"
+	os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte(content), 0644)
+
+	tool := &SearchTool{}
+	// context_lines=0 should NOT include adjacent lines
+	args := json.RawMessage(`{"pattern": "MATCH", "path": "` + tmpDir + `", "output_mode": "content", "context_lines": 0}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "| line2 MATCH") {
+		t.Errorf("expected match line, got: %q", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: default path (no path param = CWD)
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_DefaultPathIsCWD(t *testing.T) {
+	// Search for a pattern we know exists in the tool package source
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "SearchTool", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "search.go") {
+		t.Errorf("expected search.go in default-path results, got: %q", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: vendor dir and hidden file filtering
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_HiddenFilesSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, ".hidden.go"), []byte("func secret() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "visible.go"), []byte("func visible() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "visible.go") {
+		t.Error("expected visible.go in results")
+	}
+	if strings.Contains(result, ".hidden.go") {
+		t.Error("hidden file .hidden.go should be skipped")
+	}
+}
+
+func TestSearchTool_VendorDirSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "node_modules", "pkg"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "node_modules", "pkg", "lib.js"), []byte("function foo() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "main.js"), []byte("function bar() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "function", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "main.js") {
+		t.Error("expected main.js in results")
+	}
+	if strings.Contains(result, "node_modules") {
+		t.Error("node_modules contents should be skipped")
+	}
+}
+
+func TestSearchTool_GitDirSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, ".git", "objects"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, ".git", "objects", "pack"), []byte("binary data\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("func main() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "main.go") {
+		t.Error("expected main.go in results")
+	}
+	if strings.Contains(result, ".git") {
+		t.Error(".git contents should be skipped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: binary file detection
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_BinarySkip(t *testing.T) {
+	tmpDir := t.TempDir()
+	// File with null byte = binary
+	binaryContent := []byte("some text\x00more text\n")
+	os.WriteFile(filepath.Join(tmpDir, "binary.bin"), binaryContent, 0644)
+	os.WriteFile(filepath.Join(tmpDir, "text.go"), []byte("func text() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "text", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(result, "binary.bin") {
+		t.Error("binary file should be skipped")
+	}
+	if !strings.Contains(result, "text.go") {
+		t.Error("text file should still be found")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: truncation
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_FileCapTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	for i := 0; i < 150; i++ {
+		os.WriteFile(filepath.Join(tmpDir, fmt.Sprintf("file%d.go", i)),
+			[]byte(fmt.Sprintf("package p%d\nfunc F%d() {}\n", i, i)), 0644)
+	}
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "max_results": 50, "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "(output truncated)") {
+		t.Errorf("expected truncated message, got %d lines: %q",
+			strings.Count(result, "\n"), result)
+	}
+	// Count how many file paths we got
+	lines := strings.Split(strings.TrimSpace(result), "\n")
+	// Last line might be the truncation message
+	fileLines := 0
+	for _, l := range lines {
+		if strings.HasSuffix(l, ".go") {
+			fileLines++
+		}
+	}
+	if fileLines > 55 { // 50 + margin for non-file lines
+		t.Errorf("expected ~50 file results, got %d", fileLines)
+	}
+}
+
+func TestSearchTool_CharCapTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create many files, each with a match. 500 files × ~70 chars/file = 35K > 32K maxSearchChars.
+	for i := 0; i < 500; i++ {
+		content := fmt.Sprintf("package p%d\n// line with MATCH keyword number %d\nfunc F%d() {}\n", i, i, i)
+		os.WriteFile(filepath.Join(tmpDir, fmt.Sprintf("f%d.go", i)), []byte(content), 0644)
+	}
+
+	tool := &SearchTool{}
+	// files_with_matches mode — each file adds a path line, 500 files should exceed maxSearchChars
+	args := json.RawMessage(`{"pattern": "MATCH", "path": "` + tmpDir + `", "output_mode": "files_with_matches", "max_results": 500}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be truncated — either by char cap or result cap
+	if !strings.Contains(result, "(output truncated)") {
+		t.Errorf("expected truncated message, got result of length %d:\n%s...", len(result), result[:min(200, len(result))])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: long line truncation
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_LongLineTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	longLine := strings.Repeat("x", 2000) + "MATCH\n"
+	os.WriteFile(filepath.Join(tmpDir, "long.txt"), []byte(longLine), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "MATCH", "path": "` + tmpDir + `", "output_mode": "content"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Line should be truncated — no 1500 consecutive x's
+	if strings.Contains(result, strings.Repeat("x", 1500)) {
+		t.Error("long line should have been truncated")
+	}
+	// Truncation indicator should be present
+	if !strings.Contains(result, "...") {
+		t.Error("truncated line should show ...")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: nonexistent path
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_NonexistentPath(t *testing.T) {
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "test", "path": "/nonexistent/path/that/does/not/exist"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "No matches found" {
+		t.Errorf("got %q, want 'No matches found'", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: context cancellation
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_ContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	for i := 0; i < 100; i++ {
+		os.WriteFile(filepath.Join(tmpDir, fmt.Sprintf("file%d.go", i)),
+			[]byte(fmt.Sprintf("package p%d\nfunc F%d() {}\n", i, i)), 0644)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancelled
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(ctx, args)
+	// Context cancellation should not cause an error — WalkDir returns the ctx error,
+	// but we filter it the same way we filter stopErr
+	if err != nil {
+		t.Fatalf("unexpected error on cancelled context: %v", err)
+	}
+	_ = result // might be partial or empty
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: regex edge cases
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_RegexpSpecialChars(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("a.b\n"), 0644)
+
+	tool := &SearchTool{}
+
+	// In regex mode, "a.b" should match "a.b" (dot = any char)
+	args := json.RawMessage(`{"pattern": "a.b", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "a.go") {
+		t.Error("regex 'a.b' should match 'a.b'")
+	}
+
+	// Escaped dot should match literal dot
+	args2 := json.RawMessage(`{"pattern": "a\\.b", "path": "` + tmpDir + `", "output_mode": "files_with_matches"}`)
+	result2, err := tool.Execute(context.Background(), args2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result2, "a.go") {
+		t.Error("regex 'a\\.b' should match 'a.b'")
+	}
+}
+
+func TestSearchTool_InvalidRegex(t *testing.T) {
+	tool := &SearchTool{}
+	// Unbalanced bracket — invalid regex
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"pattern": "[invalid"}`))
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+	if !strings.Contains(err.Error(), "invalid regex pattern") {
+		t.Errorf("error = %v, want 'invalid regex pattern'", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: helper function truncateLine
+// ---------------------------------------------------------------------------
+
+func TestTruncateLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string // exact expected output
+	}{
+		{
+			name:  "short line unchanged",
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			name:  "exactly 1000 chars",
+			input: strings.Repeat("a", 1000),
+			want:  strings.Repeat("a", 1000),
+		},
+		{
+			name:  "1001 chars truncated",
+			input: strings.Repeat("a", 1001),
+			want:  strings.Repeat("a", 997) + "...",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "much longer truncated",
+			input: strings.Repeat("b", 5000),
+			want:  strings.Repeat("b", 997) + "...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateLine(tt.input); got != tt.want {
+				t.Errorf("truncateLine(%d) = %d chars, want %d chars",
+					len(tt.input), len(got), len(tt.want))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: helper function countMatches
+// ---------------------------------------------------------------------------
+
+func TestCountMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// File with known content
+	path := filepath.Join(tmpDir, "test.go")
+	os.WriteFile(path, []byte("line1\nfunc Foo()\nline3\nfunc Bar()\nline5\n"), 0644)
+
+	matchFunc := func(s string) bool {
+		return strings.Contains(s, "func")
+	}
+
+	count, err := countMatches(path, matchFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("countMatches = %d, want 2", count)
+	}
+}
+
+func TestCountMatches_NoMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.go")
+	os.WriteFile(path, []byte("package main\n"), 0644)
+
+	matchFunc := func(s string) bool {
+		return strings.Contains(s, "nonexistent")
+	}
+
+	count, err := countMatches(path, matchFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("countMatches = %d, want 0", count)
+	}
+}
+
+func TestCountMatches_BinaryFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "binary.bin")
+	os.WriteFile(path, []byte("text\x00more\n"), 0644)
+
+	matchFunc := func(s string) bool {
+		return true // would match everything, but binary should return 0
+	}
+
+	count, err := countMatches(path, matchFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("countMatches on binary = %d, want 0", count)
+	}
+}
+
+func TestCountMatches_NonexistentFile(t *testing.T) {
+	count, err := countMatches("/nonexistent/file.go", func(s string) bool { return true })
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if count != 0 {
+		t.Errorf("countMatches = %d, want 0 on error", count)
+	}
+}
+
+func TestCountMatches_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "empty.go")
+	os.WriteFile(path, []byte{}, 0644)
+
+	matchFunc := func(s string) bool { return true }
+	count, err := countMatches(path, matchFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("countMatches on empty = %d, want 0", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: default output mode
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_DefaultOutputMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package a\n"), 0644)
+
+	tool := &SearchTool{}
+	// No output_mode specified — should default to files_with_matches
+	args := json.RawMessage(`{"pattern": "package", "path": "` + tmpDir + `"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == "No matches found" {
+		t.Fatal("expected matches with default output mode")
+	}
+	// files_with_matches output should just be file paths, no | markers
+	if strings.Contains(result, "|") {
+		t.Errorf("default mode should not have | markers, got: %q", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: multiple files in content mode
+// ---------------------------------------------------------------------------
+
+func TestSearchTool_ContentModeMultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package a\nfunc A() {}\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package b\nfunc B() {}\n"), 0644)
+
+	tool := &SearchTool{}
+	args := json.RawMessage(`{"pattern": "func", "path": "` + tmpDir + `", "output_mode": "content"}`)
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "a.go") {
+		t.Errorf("expected a.go in content results, got: %q", result)
+	}
+	if !strings.Contains(result, "b.go") {
+		t.Errorf("expected b.go in content results, got: %q", result)
+	}
+	// Both files' match lines should be present
+	if !strings.Contains(result, "func A") {
+		t.Errorf("expected func A in results, got: %q", result)
+	}
+	if !strings.Contains(result, "func B") {
+		t.Errorf("expected func B in results, got: %q", result)
+	}
+}


### PR DESCRIPTION


### Description of Changes

- Add new SearchTool (internal/tool/search.go + search_test.go) that walks directories with filepath.WalkDir, reads files line-by-line, and matches patterns with Go stdlib regexp — no external dependencies
- Register search_tool alongside read_file, bash, etc. in executor.go, gated by the enabled_tools config map
- Enable search_tool by default in config.go, with a backward-compatible merge that fills in missing defaults for existing config files
- Fix broken indentation in executor.go shell-tool middleware check (was nested inside an orphan if-block, breaking the fail-closed guard)
- Update instruction-coding.md and instruction-planning.md to recommend search_tool over bash grep/find

### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [ X] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository.** *(To check the box, put an `x` between the brackets like this: `[x]`)*