### PR TITLE
fix: sort skill enum alphabetically in activate_skill tool

### DIFF
--- a/internal/tool/skill_tool.go
+++ b/internal/tool/skill_tool.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -90,8 +91,13 @@ func (t ActivateSkillTool) Parameters() json.RawMessage {
 	var descBuilder strings.Builder
 	descBuilder.WriteString("The name of the skill to activate. Available skills:\n")
 
-	for name, s := range t.Skills {
+	for name := range t.Skills {
 		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		s := t.Skills[name]
 		descBuilder.WriteString(fmt.Sprintf("- %s: %s\n", name, s.Metadata.Description))
 	}
 	enumStr, _ := json.Marshal(names)


### PR DESCRIPTION
### Description of Changes

#### Problem

The `activate_skill` tool's parameter schema included an `enum` list of available skill names. Because the list was built by iterating over a Go `map[string]*skill.Skill`, the iteration order was randomized on every call. This caused the enum items to "shift" between LLM prompts, confusing the model and resulting in full prompt re-processing when using llama-server

#### Fix

sort the skill names

### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [x] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository.**