### PR TITLE
feat: add skill reference discovery

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -158,6 +158,9 @@ func RegisterTools(reg *tool.Registry, enabledTools map[string]bool, isPlanning 
 			Skills: skillMap,
 			Reg:    reg,
 		})
+		reg.Register(tool.SkillReadReferenceTool{
+			Skills: skillMap,
+		})
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -131,7 +131,7 @@ func DiscoverSkillReferences(s *Skill) []string {
 			return filepath.SkipDir
 		}
 		// Skip SKILL.md itself
-		if filepath.Base(path) == "SKILL.md" {
+		if base == "SKILL.md" {
 			return nil
 		}
 		// Only include files, not directories

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -110,6 +110,44 @@ func parseSkillFile(content string) (*SkillMetadata, string, error) {
 	return &metadata, strings.TrimSpace(body.String()), nil
 }
 
+// DiscoverSkillReferences returns all files in the skill directory
+// (excluding SKILL.md, dotfiles, dotdirs, and scripts/).
+func DiscoverSkillReferences(s *Skill) []string {
+	var files []string
+	_ = filepath.Walk(s.Path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		base := filepath.Base(path)
+		// Skip dotfiles and dotdirs
+		if strings.HasPrefix(base, ".") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Skip scripts/ directory — handled separately as executable tools
+		if base == "scripts" {
+			return filepath.SkipDir
+		}
+		// Skip SKILL.md itself
+		if filepath.Base(path) == "SKILL.md" {
+			return nil
+		}
+		// Only include files, not directories
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(s.Path, path)
+		if err != nil {
+			return nil
+		}
+		files = append(files, rel)
+		return nil
+	})
+	return files
+}
+
 // DiscoverSkills finds skills in the specified directories.
 func DiscoverSkills(dirs []string) ([]*Skill, error) {
 	var skills []*Skill

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -84,7 +84,11 @@ func TestDiscoverSkillReferences(t *testing.T) {
 
 	refs := DiscoverSkillReferences(skill)
 
-	expected := map[string]bool{"a-dir/a.md": true, "m.md": true, "z-dir/z.md": true}
+	expected := map[string]bool{
+		"m.md":                         true,
+		filepath.Join("a-dir", "a.md"): true,
+		filepath.Join("z-dir", "z.md"): true,
+	}
 	if len(refs) != len(expected) {
 		t.Errorf("Expected %d refs, got %d: %v", len(expected), len(refs), refs)
 	}

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,6 +60,38 @@ Instructions here.
 
 	if skill.Metadata.Name != "my-skill" {
 		t.Errorf("Expected name 'my-skill', got '%s'", skill.Metadata.Name)
+	}
+}
+
+func TestDiscoverSkillReferences(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "discover-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	os.MkdirAll(filepath.Join(tmpDir, "z-dir"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "a-dir"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte(fmt.Sprintf("---\nname: %s\ndescription: test\n---\n", filepath.Base(tmpDir))), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "z-dir", "z.md"), []byte("z"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "a-dir", "a.md"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "m.md"), []byte("m"), 0644)
+
+	skill, err := LoadSkill(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadSkill failed: %v", err)
+	}
+
+	refs := DiscoverSkillReferences(skill)
+
+	expected := map[string]bool{"a-dir/a.md": true, "m.md": true, "z-dir/z.md": true}
+	if len(refs) != len(expected) {
+		t.Errorf("Expected %d refs, got %d: %v", len(expected), len(refs), refs)
+	}
+	for _, ref := range refs {
+		if !expected[ref] {
+			t.Errorf("Unexpected ref: %q", ref)
+		}
 	}
 }
 

--- a/internal/tool/implementations_test.go
+++ b/internal/tool/implementations_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"late/internal/common"
+	"late/internal/skill"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/internal/tool/implementations_test.go
+++ b/internal/tool/implementations_test.go
@@ -604,6 +604,161 @@ func TestBashTool_BinaryOutput(t *testing.T) {
 	}
 }
 
+func TestSkillReadReferenceTool(t *testing.T) {
+	// Create a temp skill directory with a SKILL.md and a reference file
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "my-skill")
+	err := os.MkdirAll(skillDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create SKILL.md with required frontmatter
+	skillMd := `---
+name: my-skill
+description: A test skill
+---
+
+This is the skill instructions.
+`
+	err = os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillMd), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a reference file
+	refPath := filepath.Join(skillDir, "references", "guide.md")
+	refPath = filepath.ToSlash(refPath)
+	err = os.MkdirAll(filepath.Dir(refPath), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refContent := "This is the reference content.\nIt has multiple lines.\nLine three."
+	err = os.WriteFile(refPath, []byte(refContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the *skill.Skill struct
+	s := &skill.Skill{
+		Path: skillDir,
+		Metadata: skill.SkillMetadata{
+			Name:        "my-skill",
+			Description: "A test skill",
+		},
+		Instructions: "This is the skill instructions.",
+	}
+
+	tests := []struct {
+		name        string
+		skills      map[string]*skill.Skill
+		params      json.RawMessage
+		wantContent string
+		wantErr     bool
+	}{
+		{
+			name: "happy path - read reference file",
+			skills: map[string]*skill.Skill{
+				"my-skill": s,
+			},
+			params:      json.RawMessage(`{"skill_name": "my-skill", "file_path": "references/guide.md"}`),
+			wantContent: refContent,
+		},
+		{
+			name:        "skill not found",
+			skills:      map[string]*skill.Skill{},
+			params:      json.RawMessage(`{"skill_name": "unknown-skill", "file_path": "references/guide.md"}`),
+			wantContent: "Activate", // message should mention activation
+		},
+		{
+			name: "file not found",
+			skills: map[string]*skill.Skill{
+				"my-skill": s,
+			},
+			params:      json.RawMessage(`{"skill_name": "my-skill", "file_path": "references/nonexistent.md"}`),
+			wantContent: "not found", // will be checked via contains
+		},
+		{
+			name: "path traversal blocked",
+			skills: map[string]*skill.Skill{
+				"my-skill": s,
+			},
+			params:      json.RawMessage(`{"skill_name": "my-skill", "file_path": "../etc/passwd"}`),
+			wantContent: "path traversal not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := SkillReadReferenceTool{Skills: tt.skills}
+			result, err := tool.Execute(context.Background(), tt.params)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if tt.wantContent != "" && !strings.Contains(result, tt.wantContent) {
+				t.Errorf("Expected result to contain %q, got %q", tt.wantContent, result)
+			}
+		})
+	}
+
+	// Separate test for output truncation
+	t.Run("output truncation", func(t *testing.T) {
+		// Create a large reference file (>32768 chars)
+		largeSkillDir := filepath.Join(tmpDir, "large-skill")
+		err = os.MkdirAll(largeSkillDir, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create SKILL.md
+		err = os.WriteFile(filepath.Join(largeSkillDir, "SKILL.md"), []byte(skillMd), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate a large file
+		var sb strings.Builder
+		for i := 0; i < 1000; i++ {
+			sb.WriteString(fmt.Sprintf("This is line %d of the reference file content.\n", i+1))
+		}
+		largeRefPath := filepath.Join(largeSkillDir, "references", "large.md")
+		err = os.MkdirAll(filepath.Dir(largeRefPath), 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = os.WriteFile(largeRefPath, []byte(sb.String()), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		largeSkill := &skill.Skill{
+			Path: largeSkillDir,
+			Metadata: skill.SkillMetadata{
+				Name:        "large-skill",
+				Description: "A test skill with large references",
+			},
+			Instructions: "Instructions for large-skill.",
+		}
+
+		tool := SkillReadReferenceTool{Skills: map[string]*skill.Skill{
+			"large-skill": largeSkill,
+		}}
+		result, err := tool.Execute(context.Background(), json.RawMessage(`{"skill_name": "large-skill", "file_path": "references/large.md"}`))
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		if len(result) > maxSkillReferenceChars+len("... (output truncated)")+100 {
+			t.Errorf("Output length %d exceeds expected limit", len(result))
+		}
+
+		if !strings.Contains(result, "... (output truncated)") {
+			t.Error("Expected output to contain truncation message")
+		}
+	})
+}
+
 func TestBashTool_LargeSingleLineOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific command 'printf' used")

--- a/internal/tool/skill_reference_tool.go
+++ b/internal/tool/skill_reference_tool.go
@@ -1,0 +1,98 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"late/internal/skill"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxSkillReferenceChars = 32768 // Same as maxReadFileChars
+
+// SkillReadReferenceTool reads reference files from an activated skill's directory.
+type SkillReadReferenceTool struct {
+	// Skills is a map of skill name -> skill (same type as ActivateSkillTool.Skills)
+	Skills map[string]*skill.Skill
+}
+
+func (t SkillReadReferenceTool) Name() string {
+	return "skill_read_reference"
+}
+
+func (t SkillReadReferenceTool) Description() string {
+	return "Read a reference file from an activated skill's directory. The skill must have been activated via activate_skill first."
+}
+
+func (t SkillReadReferenceTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"skill_name": {
+				"type": "string",
+				"description": "The name of the skill"
+			},
+			"file_path": {
+				"type": "string",
+				"description": "The relative path to the reference file"
+			}
+		},
+		"required": ["skill_name", "file_path"]
+	}`)
+}
+
+func (t SkillReadReferenceTool) RequiresConfirmation(args json.RawMessage) bool {
+	return false
+}
+
+func (t SkillReadReferenceTool) CallString(args json.RawMessage) string {
+	var params struct {
+		SkillName string `json:"skill_name"`
+		FilePath  string `json:"file_path"`
+	}
+	json.Unmarshal(args, &params)
+	return fmt.Sprintf("Reading skill reference: %s/%s", params.SkillName, params.FilePath)
+}
+
+func (t SkillReadReferenceTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var params struct {
+		SkillName string `json:"skill_name"`
+		FilePath  string `json:"file_path"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", err
+	}
+
+	s, ok := t.Skills[params.SkillName]
+	if !ok {
+		return fmt.Sprintf("Skill '%s' not found. Activate it first with activate_skill.", params.SkillName), nil
+	}
+
+	// Security check: reject path traversal
+	if strings.Contains(params.FilePath, "..") {
+		return "Error: path traversal not allowed", nil
+	}
+
+	// Construct absolute path
+	absPath := filepath.Join(s.Path, params.FilePath)
+
+	// Read the file
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Sprintf("Reference file not found: %s", params.FilePath), nil
+		}
+		return fmt.Sprintf("Error reading file: %v", err), nil
+	}
+
+	content := string(data)
+
+	// Truncate if too large
+	if len(content) > maxSkillReferenceChars {
+		content = content[:maxSkillReferenceChars] + "... (output truncated)"
+	}
+
+	return content, nil
+}

--- a/internal/tool/skill_tool.go
+++ b/internal/tool/skill_tool.go
@@ -138,7 +138,17 @@ func (t ActivateSkillTool) Execute(ctx context.Context, args json.RawMessage) (s
 		}
 	}
 
-	return fmt.Sprintf("Skill '%s' activated.\n\nInstructions:\n%s", s.Metadata.Name, s.Instructions), nil
+	refs := skill.DiscoverSkillReferences(s)
+	var resp strings.Builder
+	resp.WriteString(fmt.Sprintf("Skill '%s' activated.\n\nInstructions:\n%s", s.Metadata.Name, s.Instructions))
+	if len(refs) > 0 {
+		resp.WriteString("\n\n## Available References\n")
+		for _, ref := range refs {
+			resp.WriteString(fmt.Sprintf("- `%s`\n", ref))
+		}
+		resp.WriteString("\nTo read a reference file, use the `skill_read_reference` tool with the skill name and file path.\n")
+	}
+	return resp.String(), nil
 }
 
 func (t ActivateSkillTool) RequiresConfirmation(args json.RawMessage) bool { return false }


### PR DESCRIPTION
### Description of Changes

#### Summary
This commit introduces the ability for skills to carry reference files (e.g. API docs, guides, conventions) alongside their `SKILL.md`, and provides a tool to read those references after a skill is activated.

#### Changes

**New: `skill_read_reference` tool** (`internal/tool/skill_reference_tool.go`)
- Reads reference files from an activated skill's directory
- Includes path traversal protection and output truncation at 32 KB

**New: `DiscoverSkillReferences` function** (`internal/skill/skill.go`)
- Walks a skill directory and discovers all reference files
- Excludes `SKILL.md`, dotfiles/dotdirs, and `scripts/` (scripts are already handled)

**Updated: `ActivateSkillTool`** (`internal/tool/skill_tool.go`)
- Now lists available reference files in its response after activation
- Tells the user how to read them via the new tool

**Updated: Executor** (`internal/executor/executor.go`)
- Registers the new `skill_read_reference` tool

**Tests**
- `TestDiscoverSkillReferences` validates file discovery with nested dirs and exclusion rules
- `TestSkillReadReferenceTool` covers happy path, missing skill, missing file, path traversal rejection, and output truncation

#### Why
Skills often need to reference additional documentation (API specs, conventions, etc.). This gives agents first-class access to those files without requiring hardcoded paths or manual file reads.


### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [x] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository.**